### PR TITLE
fix(render/browser): don't cache a rejected launch — retry after a transient failure

### DIFF
--- a/app/render/__tests__/browser.test.ts
+++ b/app/render/__tests__/browser.test.ts
@@ -1,0 +1,37 @@
+/**
+ * `getBrowser()` memoizes a single shared Chromium launch. A FAILED launch must
+ * NOT be cached: otherwise one transient failure (OOM, missing binary mid-startup)
+ * permanently disables chart/diagram rendering for the process lifetime, because
+ * every later call hands back the same rejected promise. We mock `playwright` so
+ * the first launch rejects and the second succeeds, and assert getBrowser() retries.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const launch = vi.fn();
+vi.mock("playwright", () => ({ chromium: { launch } }));
+
+describe("getBrowser", () => {
+  beforeEach(() => {
+    launch.mockReset();
+    vi.resetModules();
+  });
+
+  it("retries after a failed launch instead of caching the rejection", async () => {
+    const browser = { close: vi.fn(async () => {}) };
+    launch
+      .mockRejectedValueOnce(new Error("launch failed"))
+      .mockResolvedValueOnce(browser);
+
+    // Import the module under test AFTER the mock is configured, so the hoisted
+    // vi.mock factory closes over an initialized `launch` (the repo's own
+    // convention in app/tools/__tests__/render-tools.test.ts).
+    const { getBrowser } = await import("../browser.js");
+
+    // First call: the launch fails — the rejection must not be memoized.
+    await expect(getBrowser()).rejects.toThrow("launch failed");
+    // Second call: a fresh launch succeeds. Before the fix this returned the
+    // cached rejected promise and rendering stayed broken forever.
+    await expect(getBrowser()).resolves.toBe(browser);
+    expect(launch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/render/browser.ts
+++ b/app/render/browser.ts
@@ -18,7 +18,15 @@ export function getBrowser(): Promise<Browser> {
     return Promise.reject(new Error("renderer is shutting down"));
   }
   if (!browserPromise) {
-    browserPromise = chromium.launch({ args: ["--no-sandbox"] });
+    // Don't cache a REJECTED launch: if chromium.launch() fails (transient OOM,
+    // missing binary mid-startup, etc.), clear the memo so the next getBrowser()
+    // retries instead of handing back the same rejected promise forever. The
+    // identity guard avoids clobbering a newer promise (e.g. after closeBrowser).
+    const launching = chromium.launch({ args: ["--no-sandbox"] });
+    browserPromise = launching;
+    launching.catch(() => {
+      if (browserPromise === launching) browserPromise = undefined;
+    });
   }
   return browserPromise;
 }


### PR DESCRIPTION
## What

`getBrowser()` memoizes `chromium.launch()` in `browserPromise` but never clears it on rejection. A single transient launch failure (OOM, a missing Chromium binary mid-startup, a sandbox hiccup) caches the **rejected** promise — so every later `getBrowser()` returns that same rejection, and `render_chart` / `render_diagram` stay broken for the entire process lifetime, with no retry.

## Fix

Clear the memo on failure so the next call re-launches — identity-guarded (`if (browserPromise === launching)`) so a late rejection can't clobber a newer launch or the `closeBrowser()` detach. The launch promise is still returned to the caller, so error surfacing on the failing call is unchanged.

## Tests

New `app/render/__tests__/browser.test.ts` mocks `playwright` (following the `vi.mock` convention in `render-tools.test.ts`) so the first launch rejects and the second succeeds, asserting `getBrowser()` retries and `launch` is called twice. Fails on `main` (the second call returns the cached rejection); passes with this change.

---

Same note as my other PR: `@copilotkit/bot-*` aren't published, so I couldn't run your full suite — but since this test only needs `playwright`, I verified it **red→green in an isolated Vitest project** (failing against the current `browser.ts`, passing with the fix).

*AI disclosure: drafted with an AI coding assistant and reviewed by me before submission.*
