### PR TITLE
docs(readme): list CopilotKit packages in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ connection) — and set three secrets.
 
 ### The packages
 
-OpenTag is a thin layer over a handful of CopilotKit packages. The `pnpm install` in step 3
-installs all of them for you — this is what each one does, so you know what you're running and
-which pieces you can drop.
+OpenTag is a thin layer on top of a handful of CopilotKit packages. The `pnpm install` in step 3 installs all of them for you — this is what each one does, so you know what you're running and which ones are optional.
 
 **Required** — every OpenTag install needs these four:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ up the moment they land — see [setup.md](./setup.md).)
 You'll run two processes: the **agent** (the LLM backend) and the **bot** (the Slack
 connection) — and set three secrets.
 
+**What you're installing.** OpenTag is built on these CopilotKit packages — `pnpm install` below pulls them in for you; they're listed here so it's clear what's under the hood without clicking through:
+
+- [`@copilotkit/bot`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot) — the platform-agnostic bot engine
+- [`@copilotkit/bot-slack`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-slack) · [`-discord`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-discord) · [`-telegram`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-telegram) · [`-whatsapp`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-whatsapp) — the platform adapters
+- [`@copilotkit/bot-ui`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-ui) — cross-platform JSX for rich messages (Block Kit, Components V2, HTML)
+- [`@copilotkit/bot-store-redis`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-store-redis) — optional Redis persistence
+- [`@copilotkit/runtime`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/runtime) — the AG-UI agent backend
+
 **1. Create a Slack app.** At [api.slack.com/apps](https://api.slack.com/apps?new_app=1) →
 *From a manifest* → paste [`slack-app-manifest.yaml`](./slack-app-manifest.yaml). Install it,
 then grab the **Bot User OAuth Token** (`xoxb-…`) and an **App-Level Token** (`xapp-…`, with the

--- a/README.md
+++ b/README.md
@@ -28,13 +28,27 @@ up the moment they land — see [setup.md](./setup.md).)
 You'll run two processes: the **agent** (the LLM backend) and the **bot** (the Slack
 connection) — and set three secrets.
 
-**What you're installing.** OpenTag is built on these CopilotKit packages — `pnpm install` below pulls them in for you; they're listed here so it's clear what's under the hood without clicking through:
+### The packages
 
-- [`@copilotkit/bot`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot) — the platform-agnostic bot engine
-- [`@copilotkit/bot-slack`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-slack) · [`-discord`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-discord) · [`-telegram`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-telegram) · [`-whatsapp`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-whatsapp) — the platform adapters
-- [`@copilotkit/bot-ui`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-ui) — cross-platform JSX for rich messages (Block Kit, Components V2, HTML)
-- [`@copilotkit/bot-store-redis`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-store-redis) — optional Redis persistence
-- [`@copilotkit/runtime`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/runtime) — the AG-UI agent backend
+OpenTag is a thin layer over a handful of CopilotKit packages. The `pnpm install` in step 3
+installs all of them for you — this is what each one does, so you know what you're running and
+which pieces you can drop.
+
+**Required** — every OpenTag install needs these four:
+
+| Package | Role |
+| --- | --- |
+| [`@copilotkit/bot`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot) | The platform-agnostic bot engine — threading, tool calls, the human-in-the-loop gate. |
+| [`@copilotkit/runtime`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/runtime) | The AG-UI agent backend that runs your LLM and tools. |
+| [`@copilotkit/bot-ui`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-ui) | Cross-platform JSX for rich messages (Block Kit on Slack, Components V2 on Discord, HTML on Telegram). |
+| [`@copilotkit/bot-slack`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-slack) | The Slack adapter — or swap it for the platform you're targeting (below). |
+
+**Optional** — add only what you use:
+
+| Package | When you need it |
+| --- | --- |
+| [`@copilotkit/bot-discord`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-discord) · [`-telegram`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-telegram) · [`-whatsapp`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-whatsapp) | Running on a platform other than Slack — one adapter per platform. |
+| [`@copilotkit/bot-store-redis`](https://github.com/CopilotKit/CopilotKit/tree/main/packages/bot-store-redis) | Durable thread persistence across restarts (defaults to in-memory without it). |
 
 **1. Create a Slack app.** At [api.slack.com/apps](https://api.slack.com/apps?new_app=1) →
 *From a manifest* → paste [`slack-app-manifest.yaml`](./slack-app-manifest.yaml). Install it,


### PR DESCRIPTION
Surface the @copilotkit/bot* and runtime packages OpenTag is built on directly in the Quick start, so readers know what gets installed without clicking through the 'built on' link.