### PR TITLE
feat: add PostHog MCP and authoritative date context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ export AGENT_URL=http://localhost:8123/   # AG-UI endpoint; the bundled Deep Age
 # export OPENAI_VERBOSITY=low
 
 # -- Internal Sources (Optional) --
+# Create a personal API key with PostHog's "MCP Server" preset.
+# The bundled connection uses CLI mode and is read-only.
+# export POSTHOG_PERSONAL_API_KEY=phx_...
+# export POSTHOG_MCP_URL=https://mcp.posthog.com/mcp?mode=cli&readonly=true
 # export LINEAR_API_KEY=lin_api_...
 # export NOTION_MCP_URL=https://your-notion-mcp.example.com/mcp
 # export NOTION_MCP_AUTH_TOKEN=your-remote-mcp-bearer-token

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -26,6 +26,8 @@ export default defineRailway(() => {
       PORT: "8123",
       OPENAI_API_KEY: preserve(),
       TAVILY_API_KEY: preserve(),
+      POSTHOG_PERSONAL_API_KEY: preserve(),
+      POSTHOG_MCP_URL: preserve(),
       LINEAR_API_KEY: preserve(),
       NOTION_MCP_URL: preserve(),
       NOTION_MCP_AUTH_TOKEN: preserve(),

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ runtime (Node + CopilotRuntime with embedded Channels)
 agent (Python + LangGraph deepagents)
           ├── OpenAI
           ├── Tavily (optional)
+          ├── PostHog MCP (optional, read-only)
           ├── Linear MCP (optional)
           └── Notion MCP (optional remote server)
 ```
@@ -66,8 +67,8 @@ Prerequisites: Node.js 22+, pnpm, Python 3.12, and
    INTELLIGENCE_API_KEY=cpk-...
    ```
 
-   Tavily, Linear, and Notion are optional. Both Node and Python load this root
-   `.env`; Railway supplies the same values as service variables.
+   Tavily, PostHog, Linear, and Notion are optional. Both Node and Python load
+   this root `.env`; Railway supplies the same values as service variables.
 
    `INTELLIGENCE_API_URL` and `INTELLIGENCE_GATEWAY_WS_URL` default to the
    production Intelligence endpoints. `INTELLIGENCE_CHANNEL_NAME` defaults to
@@ -139,6 +140,9 @@ Slack app**. Reusing it preserves the bot user, workspace installation, and
 
 - `TAVILY_API_KEY` enables live web research. Without it, OpenTag still chats,
   triages requests and renders UI from model knowledge.
+- `POSTHOG_PERSONAL_API_KEY` enables PostHog analytics through its hosted MCP.
+  Create the key with PostHog's **MCP Server** preset. The default connection is
+  token-efficient and read-only; `POSTHOG_MCP_URL` can override the endpoint.
 - `LINEAR_API_KEY` enables the hosted Linear MCP.
 - Notion is optional and remote-only. Set both `NOTION_MCP_URL` and
   `NOTION_MCP_AUTH_TOKEN`; setting only one disables the integration.
@@ -161,7 +165,7 @@ The runtime reaches the agent over Railway private networking and embeds the
 managed `open-tag` Channel. Railway sets
 `INTELLIGENCE_CHANNEL_NAME=open-tag`; Intelligence owns both platform
 adapters. The runtime API key is preserved. OpenAI is required on `agent`;
-Tavily, Linear, and remote Notion settings are optional. Connecting both
+Tavily, PostHog, Linear, and remote Notion settings are optional. Connecting both
 services to `main` enables GitHub-triggered deployments after merges.
 
 The repository configuration does not mutate the existing production Railway

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -19,6 +19,7 @@ from prompts import (
     BASE_SYSTEM_PROMPT,
     NO_WEB_SEARCH_TOOL_ADDENDUM,
     WEB_SEARCH_TOOL_ADDENDUM,
+    current_date_prompt,
 )
 from tools import web_search
 
@@ -98,7 +99,7 @@ def build_agent():
         model=llm,
         system_prompt=system_prompt,
         tools=main_tools,
-        middleware=[CopilotKitMiddleware()],
+        middleware=[CopilotKitMiddleware(), current_date_prompt],
         checkpointer=MemorySaver(),
     )
 

--- a/agent/internal_sources.py
+++ b/agent/internal_sources.py
@@ -1,4 +1,4 @@
-"""Optional Linear and Notion MCP integrations."""
+"""Optional PostHog, Linear, and Notion MCP integrations."""
 
 import asyncio
 import logging
@@ -13,6 +13,11 @@ from write_confirmation import WriteConfirmationInterceptor
 
 
 MCP_SERVERS = {
+    "posthog": {
+        "token_env": "POSTHOG_PERSONAL_API_KEY",
+        "url_env": "POSTHOG_MCP_URL",
+        "default_url": "https://mcp.posthog.com/mcp?mode=cli&readonly=true",
+    },
     "linear": {
         "token_env": "LINEAR_API_KEY",
         "url_env": "LINEAR_MCP_URL",

--- a/agent/prompts/__init__.py
+++ b/agent/prompts/__init__.py
@@ -1,5 +1,6 @@
 """OpenTag agent prompts."""
 
+from .current_date import current_date_context, current_date_prompt
 from .system import SYSTEM_PROMPT, WORKFLOW_PROMPT
 from .tools import TOOLS_PROMPT
 from .web_search import (
@@ -11,6 +12,8 @@ BASE_SYSTEM_PROMPT = SYSTEM_PROMPT + TOOLS_PROMPT + WORKFLOW_PROMPT
 
 __all__ = [
     "BASE_SYSTEM_PROMPT",
+    "current_date_context",
+    "current_date_prompt",
     "NO_WEB_SEARCH_TOOL_ADDENDUM",
     "WEB_SEARCH_TOOL_ADDENDUM",
 ]

--- a/agent/prompts/current_date.py
+++ b/agent/prompts/current_date.py
@@ -1,0 +1,41 @@
+"""Per-request calendar context for the agent."""
+
+from datetime import datetime, timezone
+
+from langchain.agents.middleware import dynamic_prompt
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import SystemMessage
+
+
+def current_date_context(now: datetime | None = None) -> str:
+    """Return authoritative UTC date guidance for the model."""
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    formatted_date = f"{current.strftime('%B')} {current.day}, {current.year}"
+    return (
+        "Current date: "
+        f"{formatted_date} (UTC). Treat this date as authoritative. Compare "
+        "dates in the user's request against it: a date before this date is "
+        "in the past, even if it falls beyond your training data."
+    )
+
+
+@dynamic_prompt
+def current_date_prompt(request: ModelRequest) -> SystemMessage:
+    """Append a freshly computed date to every model request."""
+    date_context = current_date_context()
+    system_message = request.system_message
+    if system_message is None:
+        return SystemMessage(content=date_context)
+
+    content = system_message.content
+    if isinstance(content, str):
+        updated_content = f"{content}\n\n{date_context}"
+    else:
+        updated_content = [
+            *content,
+            {"type": "text", "text": f"\n\n{date_context}"},
+        ]
+    return system_message.model_copy(update={"content": updated_content})

--- a/agent/prompts/web_search.py
+++ b/agent/prompts/web_search.py
@@ -3,7 +3,21 @@
 WEB_SEARCH_TOOL_ADDENDUM = """
 
 Live web research is available via web_search(query, max_results=5):
-- Use it when a request needs current or external information
+- You MUST call web_search before answering when a request depends on facts
+  that may have changed or happened after your training data. This includes
+  current/latest/recent claims, news, sports results or schedules, elections
+  and officeholders, prices, weather, laws, product releases, and live service
+  status
+- You MUST also search when the user names a real-world event in the current
+  calendar year or later, asks whether an event has happened, requests links
+  or sources, or explicitly asks you to search
+- Compare mentioned dates with the authoritative current date in the system
+  prompt. Never reject or "correct" a premise as being in the future based
+  only on training data; search first if the event could have happened by now
+- Example: if asked who won the 2026 World Cup after that event's date, search
+  for the result instead of claiming that the tournament has not happened
+- Do not search for timeless facts, casual conversation, writing, translation,
+  or summarization when the user has already supplied all necessary material
 - Start with one focused query and search again only when a material gap remains
 - The tool returns source snippets with URLs; synthesize the evidence and cite
   the useful sources rather than dumping raw results
@@ -13,5 +27,7 @@ NO_WEB_SEARCH_TOOL_ADDENDUM = """
 
 You do NOT have a live web research tool available right now. Answer from your
 own knowledge, state plainly when you cannot look up current or external
-information, and never claim to have searched the web.
+information, and never claim to have searched the web. Still use the
+authoritative current date from the system prompt; do not substitute the
+chronology implied by your training data.
 """

--- a/agent/tests/test_agent_configuration.py
+++ b/agent/tests/test_agent_configuration.py
@@ -101,6 +101,16 @@ def test_build_agent_bounds_graph_recursion(monkeypatch):
     assert captured["config"] == {"recursion_limit": 25}
 
 
+def test_build_agent_refreshes_current_date_before_each_model_call(monkeypatch):
+    _, captured = build_with_captured_configuration(monkeypatch)
+
+    middleware_names = [
+        type(item).__name__ for item in captured["agent"]["middleware"]
+    ]
+
+    assert "current_date_prompt" in middleware_names
+
+
 def test_openai_harness_excludes_unusable_delegation_tools(monkeypatch):
     class RecordingOpenAIModel(BaseChatModel):
         model_name: str = "gpt-5.5"

--- a/agent/tests/test_agent_configuration.py
+++ b/agent/tests/test_agent_configuration.py
@@ -39,6 +39,7 @@ def build_with_captured_configuration(monkeypatch):
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     monkeypatch.setattr(agent_mod, "internal_source_tools", lambda: [])
@@ -135,6 +136,7 @@ def test_openai_harness_excludes_unusable_delegation_tools(monkeypatch):
     model = RecordingOpenAIModel()
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     monkeypatch.setattr(agent_mod, "ChatOpenAI", lambda **_kwargs: model)
@@ -158,6 +160,7 @@ def _configure_minimal_environment(monkeypatch):
     monkeypatch.delenv("OPENAI_REASONING_EFFORT", raising=False)
     monkeypatch.delenv("OPENAI_VERBOSITY", raising=False)
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
 

--- a/agent/tests/test_health.py
+++ b/agent/tests/test_health.py
@@ -7,6 +7,7 @@ import agent as agent_mod  # noqa: E402
 def test_health_ok(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     import main
@@ -23,6 +24,7 @@ def test_health_ok(monkeypatch):
 def test_server_exposes_opentag_metadata(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     import main
@@ -50,6 +52,7 @@ def test_local_agent_port_rejects_invalid_server_port():
 def test_build_agent_without_tavily(monkeypatch, capsys):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     graph = agent_mod.build_agent()
@@ -61,6 +64,7 @@ def test_build_agent_without_tavily(monkeypatch, capsys):
 def test_build_agent_with_tavily(monkeypatch, capsys):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     graph = agent_mod.build_agent()

--- a/agent/tests/test_internal_sources.py
+++ b/agent/tests/test_internal_sources.py
@@ -8,8 +8,20 @@ from langchain_core.tools import StructuredTool
 from write_confirmation import WriteConfirmationInterceptor
 
 
+@pytest.fixture(autouse=True)
+def clear_posthog_credentials(monkeypatch):
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+
+
 def test_mcp_servers_are_configured_in_one_place():
     assert internal_sources.MCP_SERVERS == {
+        "posthog": {
+            "token_env": "POSTHOG_PERSONAL_API_KEY",
+            "url_env": "POSTHOG_MCP_URL",
+            "default_url": (
+                "https://mcp.posthog.com/mcp?mode=cli&readonly=true"
+            ),
+        },
         "linear": {
             "token_env": "LINEAR_API_KEY",
             "url_env": "LINEAR_MCP_URL",
@@ -24,9 +36,22 @@ def test_mcp_servers_are_configured_in_one_place():
 
 
 def test_internal_source_tools_empty_without_env(monkeypatch):
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
     monkeypatch.delenv("NOTION_MCP_AUTH_TOKEN", raising=False)
     assert internal_sources.internal_source_tools() == []
+
+
+def test_posthog_uses_hosted_read_only_mcp_with_personal_api_key():
+    assert internal_sources._configured_connections(
+        {"POSTHOG_PERSONAL_API_KEY": "phx_test"}
+    ) == {
+        "posthog": {
+            "transport": "streamable_http",
+            "url": "https://mcp.posthog.com/mcp?mode=cli&readonly=true",
+            "headers": {"Authorization": "Bearer phx_test"},
+        }
+    }
 
 
 @pytest.mark.parametrize(

--- a/agent/tests/test_prompts.py
+++ b/agent/tests/test_prompts.py
@@ -1,7 +1,10 @@
+from datetime import datetime, timezone
+
 from prompts import (
     BASE_SYSTEM_PROMPT,
     NO_WEB_SEARCH_TOOL_ADDENDUM,
     WEB_SEARCH_TOOL_ADDENDUM,
+    current_date_context,
 )
 
 
@@ -20,3 +23,21 @@ def test_prompt_describes_direct_optional_web_search():
     assert "web_search(query, max_results=5)" in WEB_SEARCH_TOOL_ADDENDUM
     assert "source snippets" in WEB_SEARCH_TOOL_ADDENDUM
     assert "do NOT have a live web research tool" in NO_WEB_SEARCH_TOOL_ADDENDUM
+
+
+def test_current_date_context_uses_an_authoritative_utc_date():
+    now = datetime(2026, 8, 1, 15, 30, tzinfo=timezone.utc)
+
+    context = current_date_context(now)
+
+    assert "August 1, 2026" in context
+    assert "UTC" in context
+    assert "authoritative" in context
+    assert "before this date" in context
+
+
+def test_web_search_policy_requires_temporal_verification():
+    assert "MUST call web_search" in WEB_SEARCH_TOOL_ADDENDUM
+    assert "sports results" in WEB_SEARCH_TOOL_ADDENDUM
+    assert "training data" in WEB_SEARCH_TOOL_ADDENDUM
+    assert "2026 World Cup" in WEB_SEARCH_TOOL_ADDENDUM

--- a/app/railway.test.ts
+++ b/app/railway.test.ts
@@ -68,6 +68,8 @@ describe("Railway deployment graph", () => {
     expect(agent?.variables).toMatchObject({
       OPENAI_API_KEY: { type: "preserve" },
       TAVILY_API_KEY: { type: "preserve" },
+      POSTHOG_PERSONAL_API_KEY: { type: "preserve" },
+      POSTHOG_MCP_URL: { type: "preserve" },
       LINEAR_API_KEY: { type: "preserve" },
       NOTION_MCP_URL: { type: "preserve" },
       NOTION_MCP_AUTH_TOKEN: { type: "preserve" },

--- a/setup.md
+++ b/setup.md
@@ -61,6 +61,8 @@ cp .env.example .env
 | `OPENAI_REASONING_EFFORT` | No | Defaults to `low` |
 | `OPENAI_VERBOSITY` | No | Defaults to `low` |
 | `TAVILY_API_KEY` | No | Enables live web research |
+| `POSTHOG_PERSONAL_API_KEY` | No | Enables the hosted PostHog MCP in read-only CLI mode |
+| `POSTHOG_MCP_URL` | No | Overrides the hosted PostHog MCP URL |
 | `LINEAR_API_KEY` | No | Enables the hosted Linear MCP |
 | `LINEAR_MCP_URL` | No | Overrides the hosted Linear MCP URL |
 | `NOTION_MCP_AUTH_TOKEN` | No | Bearer token for a remote Notion MCP; requires `NOTION_MCP_URL` |
@@ -177,6 +179,15 @@ Reads and UI rendering are never gated.
 Set `TAVILY_API_KEY` in the root `.env` to enable live web research. The
 `web_search` tool is not registered when the key is absent.
 
+### PostHog
+
+Create a PostHog personal API key using the **MCP Server** preset, then set
+`POSTHOG_PERSONAL_API_KEY` in the root `.env`. OpenTag connects to
+`https://mcp.posthog.com/mcp` in token-efficient CLI mode with server-enforced
+read-only access. Set `POSTHOG_MCP_URL` only to override the complete endpoint,
+including its `mode=cli&readonly=true` safety parameters. Restart `pnpm agent`
+after changing either variable.
+
 ### Linear
 
 Set `LINEAR_API_KEY` in the root `.env`. OpenTag connects to the hosted Linear
@@ -201,8 +212,8 @@ The IaC file declares exactly:
 `runtime.AGENT_URL` references the agent's Railway private domain and port.
 Production Intelligence URLs are literal configuration, the API key is
 preserved, and the Channel name is `open-tag`. `OPENAI_API_KEY` is required on
-`agent`; Tavily, Linear, and the paired remote Notion variables are optional
-preserved settings.
+`agent`; Tavily, PostHog, Linear, and the paired remote Notion variables are
+optional preserved settings.
 
 Evaluate the configuration locally without applying it:
 


### PR DESCRIPTION
## Summary

- Add optional read-only PostHog MCP integration
- Inject the authoritative UTC date into model requests
- Strengthen web-search guidance for time-sensitive facts

## Why

- Enable analytics insights through PostHog while keeping access read-only
- Prevent temporal reasoning from relying solely on stale training data

## How

- Configure PostHog credentials and Railway variable preservation
- Register the hosted PostHog MCP connection when configured
- Add dynamic date middleware and coverage for configuration, prompts, and deployment settings