### PR TITLE
feat: continue conversations in mentioned threads

### DIFF
--- a/app/channel.test.ts
+++ b/app/channel.test.ts
@@ -22,7 +22,21 @@ import { appTools } from "./tools/index.js";
 import { createOpenTagChannel } from "./channel.js";
 
 class CapturingAgent extends FakeAgent {
-  readonly calls: Array<RunAgentParameters | undefined> = [];
+  readonly calls: Array<RunAgentParameters | undefined>;
+
+  constructor(calls: Array<RunAgentParameters | undefined> = []) {
+    super();
+    this.calls = calls;
+  }
+
+  override clone(): CapturingAgent {
+    const cloned = new CapturingAgent(this.calls);
+    cloned.threadId = this.threadId;
+    cloned.agentId = this.agentId;
+    cloned.messages = structuredClone(this.messages);
+    cloned.state = structuredClone(this.state);
+    return cloned;
+  }
 
   override async runAgent(
     parameters?: RunAgentParameters,
@@ -117,6 +131,53 @@ function makeChannel(options: { agent?: FakeAgent } = {}) {
 }
 
 describe("createOpenTagChannel", () => {
+  it("continues responding in a thread after Kite is mentioned", async () => {
+    const { adapter, agent, channel } = makeChannel();
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "mentioned-thread",
+      replyTarget: {},
+      userText: "@Kite help me triage this",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m1",
+        revisionId: "m1",
+        mentioned: true,
+      },
+    });
+    await adapter.getSink().onTurn({
+      conversationKey: "mentioned-thread",
+      replyTarget: {},
+      userText: "What should I do first?",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m2",
+        revisionId: "m2",
+        mentioned: false,
+      },
+    });
+    await adapter.getSink().onTurn({
+      conversationKey: "unrelated-thread",
+      replyTarget: {},
+      userText: "Kite should not answer this",
+      platform: "slack",
+      actor: { id: "U2", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m3",
+        revisionId: "m3",
+        mentioned: false,
+      },
+    });
+
+    expect((agent as CapturingAgent).calls).toHaveLength(2);
+  });
+
   it("declares one managed Channel and retains app commands", () => {
     const channel = createOpenTagChannel("custom-channel", new FakeAgent());
     channels.push(channel);

--- a/app/channel.test.ts
+++ b/app/channel.test.ts
@@ -123,16 +123,18 @@ afterEach(async () => {
 
 function makeChannel(options: { agent?: FakeAgent } = {}) {
   const adapter = new FakeAdapter({ platform: "intelligence" });
+  const stateStore = new MemoryStore();
+  adapter.stateStore = stateStore;
   const agent = options.agent ?? new CapturingAgent();
   const channel = createOpenTagChannel("opentag", agent);
   channel.ɵruntime.addAdapter(adapter);
   channels.push(channel);
-  return { adapter, agent, channel };
+  return { adapter, agent, channel, stateStore };
 }
 
 describe("createOpenTagChannel", () => {
-  it("continues responding in a thread after Kite is mentioned", async () => {
-    const { adapter, agent, channel } = makeChannel();
+  it("subscribes when Kite is mentioned and handles a later managed delivery", async () => {
+    const { adapter, agent, channel, stateStore } = makeChannel();
 
     await channel.ɵruntime.start();
     await adapter.getSink().onTurn({
@@ -148,6 +150,10 @@ describe("createOpenTagChannel", () => {
         mentioned: true,
       },
     });
+    expect(
+      await stateStore.kv.get<boolean>("sub:mentioned-thread"),
+    ).toBe(true);
+
     await adapter.getSink().onTurn({
       conversationKey: "mentioned-thread",
       replyTarget: {},
@@ -161,21 +167,29 @@ describe("createOpenTagChannel", () => {
         mentioned: false,
       },
     });
+
+    expect((agent as CapturingAgent).calls).toHaveLength(2);
+  });
+
+  it("handles an unmentioned turn already admitted by managed ingress", async () => {
+    const { adapter, agent, channel } = makeChannel();
+
+    await channel.ɵruntime.start();
     await adapter.getSink().onTurn({
-      conversationKey: "unrelated-thread",
+      conversationKey: "managed-thread",
       replyTarget: {},
-      userText: "Kite should not answer this",
+      userText: "This turn passed the managed subscription gate",
       platform: "slack",
       actor: { id: "U2", kind: "human" },
       operation: {
         kind: "created",
-        logicalMessageId: "m3",
-        revisionId: "m3",
+        logicalMessageId: "m1",
+        revisionId: "m1",
         mentioned: false,
       },
     });
 
-    expect((agent as CapturingAgent).calls).toHaveLength(2);
+    expect((agent as CapturingAgent).calls).toHaveLength(1);
   });
 
   it("declares one managed Channel and retains app commands", () => {

--- a/app/channel.tsx
+++ b/app/channel.tsx
@@ -33,7 +33,10 @@ export function createOpenTagChannel(
     components: [IssueCard, IssueList, PageList, IncidentCard, ConfirmWrite],
   });
 
-  channel.onMention(async ({ thread, message }) => {
+  const runAgentSafely: Parameters<typeof channel.onMessage>[0] = async ({
+    thread,
+    message,
+  }) => {
     try {
       await thread.runAgent(managedRunInput(message));
     } catch (error) {
@@ -55,6 +58,17 @@ export function createOpenTagChannel(
         recovery: "posted_user_facing_error",
       });
     }
+  };
+
+  channel.onMention(async ({ thread, message }) => {
+    await thread.subscribe();
+    await runAgentSafely({ thread, message });
+  });
+
+  channel.onMessage(async ({ thread, message }) => {
+    if (!(await thread.isSubscribed())) return;
+
+    await runAgentSafely({ thread, message });
   });
 
   channel.onModalSubmit(FILE_ISSUE_CALLBACK, fileIssueSubmit);

--- a/app/channel.tsx
+++ b/app/channel.tsx
@@ -66,8 +66,6 @@ export function createOpenTagChannel(
   });
 
   channel.onMessage(async ({ thread, message }) => {
-    if (!(await thread.isSubscribed())) return;
-
     await runAgentSafely({ thread, message });
   });
 


### PR DESCRIPTION
## Summary

- Subscribe a managed conversation when Kite is explicitly mentioned.
- Continue responding to later unmentioned messages that managed ingress admits for that Thread.
- Keep unrelated channel and thread chatter silent at the managed ingress boundary.

## Why

Kite should require an explicit mention before joining a channel conversation, but users should not need to mention Kite again for every follow-up in the resulting thread.

## How

- Await `thread.subscribe()` in `onMention`, then run the existing recoverable agent path.
- Register `onMessage` without a second local `isSubscribed()` gate; managed ingress owns admission and direct messages must continue to work.
- Add focused tests that prove the mention writes subscription state and that an unmentioned turn already admitted by managed ingress reaches the agent.

Depends on https://github.com/CopilotKit/Intelligence/pull/730. Merge/deploy the Intelligence routing fix first; it is the boundary that drops untracked ambient chatter.

Validation:
- `pnpm exec vitest run app/channel.test.ts -t "subscribes when Kite is mentioned|handles an unmentioned turn"` (passes: 2 tests)
- `git diff --check` (passes)

Known baseline issues:
- The full `app/channel.test.ts` suite remains red on 7 pre-existing assertions that target an older Channels identity API; both new tests pass.
- `pnpm check-types` remains red on the repository's existing Channels 0.6 migration errors. This PR does not broaden scope into that migration.