### PR TITLE
fix(confirm-write): report failed writes, label retries, and approve one write at a time

### DIFF
--- a/agent/prompts/system.py
+++ b/agent/prompts/system.py
@@ -22,4 +22,16 @@ Operating mode:
   substantial, multi-step work needs durable notes
 - Do not write a report by default
 - When a request is ambiguous in a way that changes the action, ask one focused
-  question; otherwise make a reasonable, stated assumption and proceed"""
+  question; otherwise make a reasonable, stated assumption and proceed
+
+Writes (Linear, Notion, anything that changes data):
+- Every write is approved by a human before it runs, so a wrong argument costs
+  the user another approval. Resolve names to real records BEFORE proposing the
+  write — look the team, project, or person up rather than passing the user's
+  wording through as an identifier
+- Send the fields the user asked for plus the ones the tool requires, and no
+  others. Do not fill in optional fields speculatively, and never send a
+  dependent field without the field it depends on
+- When an approved write fails, say plainly what failed and why. If you retry,
+  say what you changed — the user is being asked to approve the same action a
+  second time and needs to know why"""

--- a/agent/tests/test_write_confirmation.py
+++ b/agent/tests/test_write_confirmation.py
@@ -3,9 +3,48 @@ import asyncio
 import copilotkit.langgraph
 import pytest
 import write_confirmation
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
-from write_confirmation import summarize_args
+from mcp.types import CallToolResult, TextContent
+from write_confirmation import failure_text, summarize_args
+
+
+def approve_and_track(monkeypatch, thread="thread-1"):
+    """Auto-approve every confirmation and record the args each card carried."""
+    cards = []
+
+    def approve(**kwargs):
+        cards.append(kwargs["args"])
+        return '{"confirmed": true}', {"confirmed": True}
+
+    monkeypatch.setattr(write_confirmation, "copilotkit_interrupt", approve)
+    monkeypatch.setattr(write_confirmation, "_thread_key", lambda: thread)
+    return cards
+
+
+def capture_reports(monkeypatch):
+    """Record what the interceptor reports back to the thread."""
+    reported = []
+
+    async def emit(_config, message):
+        reported.append(message)
+
+    monkeypatch.setattr(write_confirmation, "copilotkit_emit_message", emit)
+    monkeypatch.setattr(write_confirmation, "ensure_config", lambda: {})
+    return reported
+
+
+def error_result(text):
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)], isError=True
+    )
+
+
+def save_project(**args):
+    return MCPToolCallRequest(
+        name="save_project", args=args, server_name="linear"
+    )
 
 
 def test_summarize_args_omits_empty_values():
@@ -217,6 +256,246 @@ def test_write_confirmation_interceptor_runs_an_approved_mutation(monkeypatch):
 
     assert result == "write-result"
     assert handler_calls == [request]
+
+
+def test_failure_text_reads_an_mcp_error_result():
+    assert failure_text(error_result('Team "Growth" not found')) == (
+        'Team "Growth" not found'
+    )
+
+
+def test_failure_text_reads_an_errored_tool_message():
+    message = ToolMessage(content="boom", tool_call_id="1", status="error")
+
+    assert failure_text(message) == "boom"
+
+
+def test_failure_text_is_none_for_successful_results():
+    ok = CallToolResult(content=[TextContent(type="text", text="done")])
+
+    assert failure_text(ok) is None
+    assert failure_text(ToolMessage(content="done", tool_call_id="1")) is None
+    assert failure_text("write-result") is None
+
+
+def test_failure_text_names_an_error_with_no_readable_content():
+    assert failure_text(CallToolResult(content=[], isError=True)) == (
+        "the tool reported an error"
+    )
+
+
+def test_failure_text_truncates_an_overlong_error():
+    assert failure_text(error_result("x" * 400)) == "x" * 240 + "…"
+
+
+def test_a_failed_write_is_reported_to_the_thread(monkeypatch):
+    approve_and_track(monkeypatch)
+    reported = capture_reports(monkeypatch)
+
+    async def handler(_request):
+        return error_result('Team "Growth" not found')
+
+    asyncio.run(
+        write_confirmation.WriteConfirmationInterceptor()(
+            save_project(name="channels sdk launch"), handler
+        )
+    )
+
+    assert reported == ['⚠️ **Save project** failed — Team "Growth" not found']
+
+
+def test_a_raised_write_failure_is_reported_and_still_propagates(monkeypatch):
+    approve_and_track(monkeypatch)
+    reported = capture_reports(monkeypatch)
+
+    async def handler(_request):
+        raise TimeoutError("linear timed out")
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(
+            write_confirmation.WriteConfirmationInterceptor()(
+                save_project(name="channels sdk launch"), handler
+            )
+        )
+
+    assert reported == ["⚠️ **Save project** failed — TimeoutError: linear timed out"]
+
+
+def test_a_successful_write_is_not_reported_as_a_failure(monkeypatch):
+    approve_and_track(monkeypatch)
+    reported = capture_reports(monkeypatch)
+
+    async def handler(_request):
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    asyncio.run(
+        write_confirmation.WriteConfirmationInterceptor()(
+            save_project(name="channels sdk launch"), handler
+        )
+    )
+
+    assert reported == []
+
+
+def test_a_retry_card_names_the_attempt_and_the_previous_failure(monkeypatch):
+    cards = approve_and_track(monkeypatch)
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    async def failing(_request):
+        return error_result('Team "Growth" not found')
+
+    async def succeeding(_request):
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    asyncio.run(interceptor(save_project(setTeams=["Growth"]), failing))
+    asyncio.run(
+        interceptor(save_project(setTeams=["Growth & Partnerships"]), succeeding)
+    )
+
+    # The first card asks cold; the second says why it is asking again.
+    assert "attempt" not in cards[0]
+    assert cards[1]["attempt"] == 2
+    assert cards[1]["previous_error"] == 'Team "Growth" not found'
+
+
+def test_a_third_card_counts_every_failed_attempt(monkeypatch):
+    cards = approve_and_track(monkeypatch)
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    async def failing(_request):
+        return error_result("still wrong")
+
+    for _ in range(3):
+        asyncio.run(interceptor(save_project(name="x"), failing))
+
+    assert [card.get("attempt") for card in cards] == [None, 2, 3]
+
+
+def test_a_succeeded_write_clears_the_retry_banner(monkeypatch):
+    cards = approve_and_track(monkeypatch)
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    async def failing(_request):
+        return error_result("nope")
+
+    async def succeeding(_request):
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    asyncio.run(interceptor(save_project(name="x"), failing))
+    asyncio.run(interceptor(save_project(name="x"), succeeding))
+    asyncio.run(interceptor(save_project(name="x"), succeeding))
+
+    assert cards[2].get("attempt") is None
+
+
+def test_a_declined_write_clears_the_retry_banner(monkeypatch):
+    cards = []
+    capture_reports(monkeypatch)
+    monkeypatch.setattr(write_confirmation, "_thread_key", lambda: "thread-1")
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    confirmed = [True, False, True]
+
+    def respond(**kwargs):
+        cards.append(kwargs["args"])
+        answer = confirmed.pop(0)
+        return f'{{"confirmed": {str(answer).lower()}}}', {"confirmed": answer}
+
+    monkeypatch.setattr(write_confirmation, "copilotkit_interrupt", respond)
+
+    async def failing(_request):
+        return error_result("nope")
+
+    asyncio.run(interceptor(save_project(name="x"), failing))
+    asyncio.run(interceptor(save_project(name="x"), failing))
+    asyncio.run(interceptor(save_project(name="x"), failing))
+
+    # Card 2 cites the failure and is declined; card 3 starts clean.
+    assert cards[1]["attempt"] == 2
+    assert cards[2].get("attempt") is None
+
+
+def test_failures_never_leak_between_conversations(monkeypatch):
+    cards = []
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    def approve(**kwargs):
+        cards.append(kwargs["args"])
+        return '{"confirmed": true}', {"confirmed": True}
+
+    monkeypatch.setattr(write_confirmation, "copilotkit_interrupt", approve)
+
+    async def failing(_request):
+        return error_result("nope")
+
+    monkeypatch.setattr(write_confirmation, "_thread_key", lambda: "thread-a")
+    asyncio.run(interceptor(save_project(name="x"), failing))
+    monkeypatch.setattr(write_confirmation, "_thread_key", lambda: "thread-b")
+    asyncio.run(interceptor(save_project(name="x"), failing))
+
+    # thread-b has failed nothing; its first card must not cite thread-a's error.
+    assert cards[1].get("attempt") is None
+
+
+def test_failures_are_forgotten_without_a_thread_id(monkeypatch):
+    cards = approve_and_track(monkeypatch, thread=None)
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    async def failing(_request):
+        return error_result("nope")
+
+    asyncio.run(interceptor(save_project(name="x"), failing))
+    asyncio.run(interceptor(save_project(name="x"), failing))
+
+    # No thread to attribute the failure to, so nothing is remembered — better
+    # than a shared key that would label an unrelated conversation's card.
+    assert cards[1].get("attempt") is None
+
+
+def test_tracked_failures_stay_bounded(monkeypatch):
+    approve_and_track(monkeypatch)
+    capture_reports(monkeypatch)
+    interceptor = write_confirmation.WriteConfirmationInterceptor()
+
+    async def failing(_request):
+        return error_result("nope")
+
+    for i in range(write_confirmation._MAX_TRACKED_FAILURES + 10):
+        monkeypatch.setattr(
+            write_confirmation, "_thread_key", lambda i=i: f"thread-{i}"
+        )
+        asyncio.run(interceptor(save_project(name="x"), failing))
+
+    assert len(interceptor._failures) == write_confirmation._MAX_TRACKED_FAILURES
+
+
+def test_a_broken_failure_report_does_not_break_the_write(monkeypatch):
+    approve_and_track(monkeypatch)
+
+    async def emit(_config, _message):
+        raise RuntimeError("no stream")
+
+    monkeypatch.setattr(write_confirmation, "copilotkit_emit_message", emit)
+    monkeypatch.setattr(write_confirmation, "ensure_config", lambda: {})
+
+    failed = error_result("nope")
+
+    async def failing(_request):
+        return failed
+
+    result = asyncio.run(
+        write_confirmation.WriteConfirmationInterceptor()(
+            save_project(name="x"), failing
+        )
+    )
+
+    # The tool's own result still reaches the agent, which can retry or explain.
+    assert result is failed
 
 
 def test_write_confirmation_interceptor_rejects_a_malformed_resume(

--- a/agent/write_confirmation.py
+++ b/agent/write_confirmation.py
@@ -1,9 +1,13 @@
 """Approval enforcement for mutating MCP tools."""
 
 import json
+import logging
 import re
+from collections import OrderedDict
 
-from copilotkit.langgraph import copilotkit_interrupt
+from copilotkit.langgraph import copilotkit_emit_message, copilotkit_interrupt
+from langchain_core.messages import ToolMessage
+from langchain_core.runnables.config import ensure_config
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.interceptors import (
     MCPToolCallRequest,
@@ -17,6 +21,15 @@ _MAX_FIELDS = 12
 
 # Longest value rendered in a cell before it is elided.
 _MAX_VALUE = 300
+
+# Longest failure text carried into the thread and onto the next card.
+_MAX_ERROR = 240
+
+# How many (thread, tool) failures are remembered at once. The interceptor
+# outlives every conversation, so this memory is bounded rather than unbounded.
+_MAX_TRACKED_FAILURES = 64
+
+logger = logging.getLogger(__name__)
 
 
 def _humanize(key: str) -> str:
@@ -76,6 +89,62 @@ def summarize_args(args: dict) -> list[dict]:
     return fields
 
 
+def _flatten_text(content) -> str:
+    """Best-effort readable text from an MCP or LangChain tool payload."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        parts = [content]
+    elif isinstance(content, (list, tuple)):
+        parts = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if text is None and isinstance(item, dict):
+                text = item.get("text")
+            parts.append(str(item if text is None else text))
+    else:
+        parts = [str(content)]
+
+    text = " ".join(part.strip() for part in parts if part and part.strip())
+    return text[:_MAX_ERROR] + "…" if len(text) > _MAX_ERROR else text
+
+
+def failure_text(result) -> str | None:
+    """The failure this tool call reported, or `None` when it succeeded.
+
+    Interceptors sit *inside* `langchain_mcp_adapters`' result conversion, so a
+    failed call arrives here as `CallToolResult(isError=True)` rather than the
+    `ToolException` the agent eventually sees. Reading it here is the only
+    point where the write's real outcome is known.
+    """
+    if isinstance(result, ToolMessage):
+        if result.status != "error":
+            return None
+        return _flatten_text(result.content) or "the tool reported an error"
+    if not getattr(result, "isError", False):
+        return None
+    return (
+        _flatten_text(getattr(result, "content", None))
+        or "the tool reported an error"
+    )
+
+
+def _thread_key() -> str | None:
+    """The running graph's thread id, or `None` outside a graph.
+
+    Failure memory is keyed by this so one conversation's failed write can
+    never label another conversation's confirmation card. Without a thread id
+    the interceptor simply forgets, rather than sharing across threads.
+    """
+    try:
+        configurable = ensure_config().get("configurable") or {}
+    except Exception:
+        # Reading the ambient config must never be what stops a write.
+        return None
+    thread_id = configurable.get("thread_id")
+    return str(thread_id) if thread_id else None
+
+
 class WriteConfirmationInterceptor:
     """Require approval for every MCP tool not marked read-only."""
 
@@ -87,12 +156,56 @@ class WriteConfirmationInterceptor:
 
     def __init__(self):
         self._read_only_tools = set(self._KNOWN_READ_ONLY_TOOLS)
+        # (thread id, tool name) -> (attempts so far, last failure text).
+        self._failures: OrderedDict[tuple[str, str], tuple[int, str]] = (
+            OrderedDict()
+        )
 
     def register_tools(self, tools: list[BaseTool]) -> None:
         for source_tool in tools:
             metadata = source_tool.metadata or {}
             if metadata.get("readOnlyHint") is True:
                 self._read_only_tools.add(source_tool.name)
+
+    def _remember_failure(self, key, error: str) -> None:
+        if key is None:
+            return
+        attempts, _ = self._failures.pop(key, (0, ""))
+        self._failures[key] = (attempts + 1, error)
+        while len(self._failures) > _MAX_TRACKED_FAILURES:
+            self._failures.popitem(last=False)
+
+    def _forget_failure(self, key) -> None:
+        if key is not None:
+            self._failures.pop(key, None)
+
+    def _retry_args(self, key) -> dict:
+        """Attempt number and prior failure to render on the next card."""
+        if key is None or key not in self._failures:
+            return {}
+        attempts, error = self._failures[key]
+        return {"attempt": attempts + 1, "previous_error": error}
+
+    async def _report_failure(self, action: str, error: str) -> None:
+        """Tell the thread the confirmed write failed.
+
+        Without this the approval card is the last word the user sees, and a
+        rejected write is indistinguishable from a completed one.
+        """
+        try:
+            # Markdown bold, matching the cards — the platform renderers
+            # convert `**x**` to each surface's own bold.
+            await copilotkit_emit_message(
+                ensure_config(),
+                f"⚠️ **{action}** failed — {error}",
+            )
+        except Exception as emit_error:
+            # The tool result still reaches the agent, which can retry or
+            # explain; a failed report must not also fail the turn.
+            logger.warning(
+                "[WRITE] could not report a failed write to the thread: %s",
+                type(emit_error).__name__,
+            )
 
     async def __call__(
         self,
@@ -104,9 +217,15 @@ class WriteConfirmationInterceptor:
 
         action = request.name.replace("_", " ").replace("-", " ").strip()
         action = action[:1].upper() + action[1:]
+        thread = _thread_key()
+        key = None if thread is None else (thread, request.name)
         _answer, response = copilotkit_interrupt(
             action="confirm_write",
-            args={"action": action, "fields": summarize_args(request.args)},
+            args={
+                "action": action,
+                "fields": summarize_args(request.args),
+                **self._retry_args(key),
+            },
         )
 
         if isinstance(response, str):
@@ -124,6 +243,9 @@ class WriteConfirmationInterceptor:
             )
 
         if response["confirmed"] is False:
+            # The user ended this sequence; the next confirmation for this tool
+            # starts from a clean slate rather than citing an abandoned attempt.
+            self._forget_failure(key)
             return CallToolResult(
                 content=[
                     TextContent(
@@ -133,4 +255,19 @@ class WriteConfirmationInterceptor:
                 ]
             )
 
-        return await handler(request)
+        try:
+            result = await handler(request)
+        except Exception as error:
+            failure = _flatten_text(f"{type(error).__name__}: {error}")
+            self._remember_failure(key, failure)
+            await self._report_failure(action, failure)
+            raise
+
+        failure = failure_text(result)
+        if failure is None:
+            self._forget_failure(key)
+            return result
+
+        self._remember_failure(key, failure)
+        await self._report_failure(action, failure)
+        return result

--- a/app/channel.tsx
+++ b/app/channel.tsx
@@ -78,6 +78,8 @@ export function createOpenTagChannel(
         action={args.action}
         fields={args.fields}
         detail={args.detail ?? undefined}
+        attempt={args.attempt}
+        previousError={args.previous_error ?? undefined}
       />,
     );
   });

--- a/app/human-in-the-loop/__tests__/confirm-write.test.tsx
+++ b/app/human-in-the-loop/__tests__/confirm-write.test.tsx
@@ -253,6 +253,77 @@ describe("ConfirmWrite", () => {
     expect(json).toContain("Action.Submit");
   });
 
+  it("says nothing about retries on a first attempt", () => {
+    const { blocks } = renderSlackMessage(
+      renderToIR(<ConfirmWrite action="Save project" />),
+    );
+
+    expect(JSON.stringify(blocks)).not.toMatch(/Attempt|failed/i);
+  });
+
+  it("names the attempt and the previous failure when re-asking", () => {
+    const { blocks } = renderSlackMessage(
+      renderToIR(
+        <ConfirmWrite
+          action="Save project"
+          fields={[{ label: "Set teams", value: "Growth & Partnerships" }]}
+          attempt={2}
+          previousError={'Team "Growth" not found'}
+        />,
+      ),
+    );
+
+    const contexts = blocks.filter((b) => b.type === "context") as {
+      elements: { text: string }[];
+    }[];
+    // The retry banner leads, so the reason for the second ask is visible
+    // before the arguments the approver is being asked to re-approve.
+    expect(contexts[0]?.elements[0]?.text).toContain("Attempt 2");
+    expect(contexts[0]?.elements[0]?.text).toContain('Team "Growth" not found');
+    expect(blocks.findIndex((b) => b.type === "context")).toBeLessThan(
+      blocks.findIndex((b) => b.type === "table"),
+    );
+    // The buttons and their lock note survive the extra block.
+    expect(
+      contexts[contexts.length - 1]?.elements[0]?.text,
+    ).toContain("Nothing is changed until you click");
+  });
+
+  it("still flags a retry when the failure text is missing", () => {
+    const { blocks } = renderSlackMessage(
+      renderToIR(<ConfirmWrite action="Save project" attempt={3} />),
+    );
+
+    const context = blocks.find((b) => b.type === "context") as
+      | { elements: { text: string }[] }
+      | undefined;
+    expect(context?.elements[0]?.text).toContain("Attempt 3");
+    expect(context?.elements[0]?.text).not.toContain("undefined");
+  });
+
+  it("treats attempt 1 as a first ask, not a retry", () => {
+    const { blocks } = renderSlackMessage(
+      renderToIR(<ConfirmWrite action="Save project" attempt={1} />),
+    );
+
+    expect(JSON.stringify(blocks)).not.toMatch(/Attempt/i);
+  });
+
+  it("renders the retry banner on a Teams Adaptive Card too", () => {
+    const card = renderAdaptiveCard(
+      renderToIR(
+        <ConfirmWrite
+          action="Save project"
+          attempt={2}
+          previousError="Team not found"
+        />,
+      ),
+    );
+
+    expect(JSON.stringify(card)).toContain("Attempt 2");
+    expect(JSON.stringify(card)).toContain("Team not found");
+  });
+
   it("approve onClick updates the picker and resumes the interrupted agent", async () => {
     const ir = renderToIR(
       <ConfirmWrite action="Create Linear issue" detail="CPK-9: ..." />,
@@ -292,6 +363,33 @@ describe("ConfirmWrite", () => {
       | { elements: { text: string }[] }
       | undefined;
     expect(context?.elements[0]?.text).toContain("Approved");
+  });
+
+  it("the approved card does not claim a write that may still fail", async () => {
+    const ir = renderToIR(<ConfirmWrite action="Save project" />);
+    const save = buttonByText(ir, "Save");
+    const update = vi.fn(async () => ({ id: "m1" }));
+    const ctx = {
+      thread: { update, resume: vi.fn(async () => ({ id: "m2" })) },
+      message: { ref: { id: "m1" } },
+    } as unknown as InteractionContext;
+
+    await (save.props.onClick as ClickHandler)(ctx);
+
+    const [, renderable] = update.mock.calls[0] as unknown as [
+      { id: string },
+      Parameters<typeof renderToIR>[0],
+    ];
+    const { blocks } = renderSlackMessage(renderToIR(renderable));
+    const context = blocks.find((b) => b.type === "context") as
+      | { elements: { text: string }[] }
+      | undefined;
+
+    // This card is never revisited: the agent, not the click handler, learns
+    // the outcome. It must therefore claim only that the write was started —
+    // a card reading "writing now" outlives a write that Linear rejected.
+    expect(context?.elements[0]?.text).toContain("running the write");
+    expect(context?.elements[0]?.text).not.toMatch(/written|wrote|saved|done/i);
   });
 
   it("does not resume approval when the status update fails", async () => {

--- a/app/human-in-the-loop/confirm-write.tsx
+++ b/app/human-in-the-loop/confirm-write.tsx
@@ -46,6 +46,14 @@ interface ConfirmWriteProps {
    * when an agent revision predating `fields` is what sent the interrupt.
    */
   detail?: string;
+  /**
+   * Which attempt at this write is being confirmed. `2` and up mean the user
+   * already approved this action once and the write was rejected — without
+   * saying so, a corrected retry is indistinguishable from asking twice.
+   */
+  attempt?: number;
+  /** Why the previous attempt failed, quoted from the tool that rejected it. */
+  previousError?: string;
 }
 
 async function resumeOrShowFailure(
@@ -127,12 +135,36 @@ function confirmLabel(verb: string): string {
   return verb.toLowerCase() === DECLINE_LABEL.toLowerCase() ? "Confirm" : verb;
 }
 
-export function ConfirmWrite({ action, fields, detail }: ConfirmWriteProps) {
+/**
+ * The retry banner, shown only from the second attempt on. It names the
+ * attempt number and quotes the failure, so an approver can tell a corrected
+ * retry from the same question asked again — and can see what to fix.
+ */
+function retryNotice(attempt: number, previousError?: string) {
+  const cause = previousError ? `: ${previousError}` : ".";
+  return (
+    <Context>
+      {`♻️  Attempt ${attempt} — an earlier approved attempt failed${cause}`}
+    </Context>
+  );
+}
+
+export function ConfirmWrite({
+  action,
+  fields,
+  detail,
+  attempt,
+  previousError,
+}: ConfirmWriteProps) {
   const body = fields?.length
     ? fieldTable(fields)
     : detail
       ? <Section>{detail}</Section>
       : null;
+
+  const retry = attempt && attempt > 1
+    ? retryNotice(attempt, previousError)
+    : null;
 
   const verb = verbOf(action);
   const label = confirmLabel(verb);
@@ -143,6 +175,7 @@ export function ConfirmWrite({ action, fields, detail }: ConfirmWriteProps) {
   return (
     <Message accent="#E2B340">
       <Header>{`📝 ${action}?`}</Header>
+      {retry}
       {body}
       <Context>
         {`🔒  Nothing is changed until you click **${label}**.`}
@@ -156,7 +189,16 @@ export function ConfirmWrite({ action, fields, detail }: ConfirmWriteProps) {
               message.ref,
               <Message accent="#27AE60">
                 <Header>{`✅ ${action}`}</Header>
-                <Context>{"✅  Approved — writing now."}</Context>
+                {/*
+                  Claims only what is true at click time. The card cannot be
+                  updated with the outcome — the agent, not this handler, learns
+                  whether the tool accepted the write — so the agent reports the
+                  result in the thread (see `_report_failure`) rather than
+                  leaving this card asserting a write that may have failed.
+                */}
+                <Context>
+                  {"✅  Approved — running the write. The result follows below."}
+                </Context>
               </Message>,
             );
             await resumeOrShowFailure(

--- a/app/interrupt.test.ts
+++ b/app/interrupt.test.ts
@@ -94,6 +94,51 @@ describe("parseConfirmWriteInterrupt", () => {
     ).toThrow();
   });
 
+  it("parses the retry context the agent adds to a re-asked write", () => {
+    const args = parseConfirmWriteInterrupt(
+      JSON.stringify({
+        ...realEnvelope,
+        __copilotkit_interrupt_value__: {
+          action: "confirm_write",
+          args: {
+            action: "Save project",
+            fields: [{ label: "Name", value: "OpenTag" }],
+            attempt: 2,
+            previous_error: 'Team "Growth" not found',
+          },
+        },
+      }),
+    ).args;
+
+    expect(args.attempt).toBe(2);
+    expect(args.previous_error).toBe('Team "Growth" not found');
+  });
+
+  it("accepts a first attempt with no retry context", () => {
+    const args = parseConfirmWriteInterrupt(
+      JSON.stringify(realEnvelope),
+    ).args;
+
+    expect(args.attempt).toBeUndefined();
+    expect(args.previous_error).toBeUndefined();
+  });
+
+  it("rejects a nonsensical attempt number", () => {
+    for (const attempt of [0, -1, 1.5]) {
+      expect(() =>
+        parseConfirmWriteInterrupt(
+          JSON.stringify({
+            ...realEnvelope,
+            __copilotkit_interrupt_value__: {
+              action: "confirm_write",
+              args: { action: "Save project", attempt },
+            },
+          }),
+        ),
+      ).toThrow();
+    }
+  });
+
   it("rejects malformed envelopes and other actions", () => {
     expect(() =>
       parseConfirmWriteInterrupt(

--- a/app/interrupt.ts
+++ b/app/interrupt.ts
@@ -11,6 +11,13 @@ const confirmWriteInterruptSchema = z.object({
         .optional(),
       /** Legacy pre-`fields` summary; still accepted across a deploy skew. */
       detail: z.string().nullish(),
+      /**
+       * Which attempt at this write the card is asking about. Absent on a
+       * first attempt; `2` and up mean an earlier approved attempt failed.
+       */
+      attempt: z.number().int().min(1).optional(),
+      /** Why the previous attempt at this same write failed. */
+      previous_error: z.string().nullish(),
     }),
   }),
   __copilotkit_messages__: z.array(z.unknown()),


### PR DESCRIPTION
## What happened

Creating one Linear project asked Jerel for approval **four times** ([Slack thread](https://copilotkit.slack.com/archives/C0B49MEJ1HQ/p1785786759395069)).

Cards were posted at 12:53:08, 12:53:26, 12:53:41 and 12:54:02 PDT. Three were approved; one is still sitting there pending. Only **one** project exists in Linear, created at 19:54:11Z — so the first two approvals wrote nothing.

The winning call's arguments differ from what the first card proposed:

| | Card #1 proposed | Project actually created |
|---|---|---|
| Team | `Growth` | **Growth & Partnerships** |
| `startDateResolution` | `month` | *(null)* |
| `targetDateResolution` | `month` | *(null)* |

The agent was correcting itself. There is no Linear team named "Growth", and `startDateResolution` is documented as pair-with-`startDate` but was sent alone. Approve → Linear rejects → agent searches → corrects → **the gate fires again, because it is per tool call**.

Nothing communicated any of that. Each card flipped to "Approved — writing now" and stayed there even when the write was rejected, so the thread read as the same question asked over and over.

## What this changes

**Retries are labelled.** A re-ask now opens with the attempt number and the reason the last one failed:

```
📝 Save project?
♻️  Attempt 2 — an earlier approved attempt failed: Team "Growth" not found
    Name       |  channels sdk launch
    Priority   |  0
    Set teams  |  Growth & Partnerships
🔒  Nothing is changed until you click *Save*.
    (Save) (Cancel)
```

First asks are unchanged.

**Failed writes reach the thread.** The interceptor sits *inside* `langchain_mcp_adapters`' result conversion, so it sees `CallToolResult(isError=True)` before it becomes the `ToolException` the agent handles — the only point where the write's real outcome is known. On failure it emits `⚠️ **Save project** failed — <error>` and remembers the failure for the next card.

Failure memory is keyed by the graph's `thread_id`, so one conversation can never label another's card, and is dropped entirely when there is no thread id rather than sharing a key. Success and decline clear it; the map is bounded, since the interceptor outlives every conversation.

**The approved card stops over-claiming.** It is never revisited — the agent, not the click handler, learns whether the tool accepted the write — so it now says the write is *running* and lets the outcome follow in the thread.

**Prompt rules address the cause.** Resolve names to real records before proposing a write; send only required and requested fields; say what changed when retrying.

## Testing

- Agent: **70 passed** (18 new — error extraction from MCP/LangChain payloads, per-thread isolation, attempt counting, decline/success clearing, bounded memory, best-effort reporting)
- Channel: **158 passed** (9 new — retry banner on Slack and Teams, schema round-trip, approved-copy guard)
- Rendered the attempt-2 card through the real Slack renderer (output above)

## Pre-existing, not touched

`app/cleanup.test.ts` fails and `tsc` reports 4 errors on a clean tree too: `package.json` declares `@copilotkit/channels@0.6.1` while the installed tree is `0.2.2-canary.rc-1`. Same 4 errors and same 1 failing test before and after this branch. That is #15 / #16 territory.

## Still open from the investigation

1. The abandoned card from the incident is **still armed** in Slack. The runtime restarted at 19:55, so nothing is waiting behind it — clicking Save now would likely start a fresh run and create a duplicate project.
2. Resume runs bypass the per-conversation turn lock in channels-core (`onTurn` locks, `onInteraction` does not). That is how two runs completed on the same thread at the same nanosecond (19:53:49.084168 / .084177) — a click racing a message. SDK-side fix.
