### PR TITLE
feat(channel): answer follow-ups after a mention subscribes

### DIFF
--- a/app/channel.test.ts
+++ b/app/channel.test.ts
@@ -116,6 +116,31 @@ function makeChannel(options: { agent?: FakeAgent } = {}) {
   return { adapter, agent, channel };
 }
 
+/** Turn dedup keys off `logicalMessageId`/`revisionId`, so each turn needs its own id. */
+function messageOperation(id: string, mentioned: boolean) {
+  return {
+    kind: "created" as const,
+    logicalMessageId: id,
+    revisionId: id,
+    mentioned,
+  };
+}
+
+/**
+ * Count agent runs from inside the script rather than from a field on the agent:
+ * every turn runs on a *clone*, and `FakeAgent.clone()` copies the remaining
+ * script but resets its own counters, so instance state under-reports.
+ */
+function countingAgent(maxRuns = 5) {
+  const runs: string[] = [];
+  const agent = new FakeAgent(
+    Array.from({ length: maxRuns }, () => async () => {
+      runs.push("run");
+    }),
+  );
+  return { agent, runs };
+}
+
 describe("createOpenTagChannel", () => {
   it("declares one managed Channel and retains app commands", () => {
     const channel = createOpenTagChannel("custom-channel", new FakeAgent());
@@ -194,6 +219,53 @@ describe("createOpenTagChannel", () => {
         value: "Ada (teams id T1)",
       },
     ]);
+  });
+
+  it("stays quiet in a conversation that never addressed it", async () => {
+    const { agent, runs } = countingAgent();
+    const { adapter, channel } = makeChannel({ agent });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "c1",
+      replyTarget: {},
+      userText: "chatter between two humans",
+      platform: "slack",
+      operation: messageOperation("m1", false),
+    });
+
+    expect(runs).toHaveLength(0);
+  });
+
+  it("answers follow-ups once a mention subscribes that conversation", async () => {
+    const { agent, runs } = countingAgent();
+    const { adapter, channel } = makeChannel({ agent });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "c1",
+      replyTarget: {},
+      userText: "@opentag triage my issues",
+      platform: "slack",
+      operation: messageOperation("m1", true),
+    });
+    await adapter.getSink().onTurn({
+      conversationKey: "c1",
+      replyTarget: {},
+      userText: "and the second one?",
+      platform: "slack",
+      operation: messageOperation("m2", false),
+    });
+    // Subscriptions are per conversation, so an unrelated one stays quiet.
+    await adapter.getSink().onTurn({
+      conversationKey: "c2",
+      replyTarget: {},
+      userText: "unrelated chatter",
+      platform: "slack",
+      operation: messageOperation("m3", false),
+    });
+
+    expect(runs).toHaveLength(2);
   });
 
   it("injects managed content parts as the current agent prompt", async () => {

--- a/app/channel.tsx
+++ b/app/channel.tsx
@@ -1,6 +1,7 @@
 import {
   createChannel,
   type Channel,
+  type ChannelHandler,
   type CreateChannelOptions,
 } from "@copilotkit/channels";
 import {
@@ -33,7 +34,7 @@ export function createOpenTagChannel(
     components: [IssueCard, IssueList, PageList, IncidentCard, ConfirmWrite],
   });
 
-  channel.onMention(async ({ thread, message }) => {
+  const runTurn: ChannelHandler = async ({ thread, message }) => {
     try {
       await thread.runAgent(managedRunInput(message));
     } catch (error) {
@@ -55,6 +56,20 @@ export function createOpenTagChannel(
         recovery: "posted_user_facing_error",
       });
     }
+  };
+
+  // Being addressed joins the conversation; from then on OpenTag answers every
+  // message in it. Dispatch is exclusive — a mentioned turn goes to `onMention`
+  // whenever any is registered — so the mention that subscribes runs once.
+  channel.onMention(async (ctx) => {
+    await ctx.thread.subscribe();
+    await runTurn(ctx);
+  });
+
+  // Without the `isSubscribed` guard this answers every message in every
+  // conversation the bot can see, including ones it was never invited into.
+  channel.onMessage(async (ctx) => {
+    if (await ctx.thread.isSubscribed()) await runTurn(ctx);
   });
 
   channel.onModalSubmit(FILE_ISSUE_CALLBACK, fileIssueSubmit);


### PR DESCRIPTION
## What

`onMention` ran the agent but never subscribed the conversation, and no `onMessage` handler was registered at all — so OpenTag answered only when explicitly addressed, on every single turn.

- A mention now subscribes the conversation and runs the agent.
- Later messages in that conversation run the agent too, guarded by `isSubscribed()` so the bot stays silent in conversations it was never invited into.
- The existing error handling (user-facing reply + `reportRecoverableError`, `AggregateError` when the reply itself fails) moves into a shared `runTurn` handler instead of being duplicated across both entry points.

Dispatch is exclusive in `channels-core` — a mentioned turn goes to `onMention` whenever any handler is registered, and to `onMessage` otherwise — so the mention that subscribes still runs the agent exactly once.

`runAgent(managedRunInput(message))` is kept rather than a bare `runAgent()`: `managedRunInput` carries the multimodal content parts and the per-platform tools/context that a managed turn needs.

## Testing

Two new tests in `app/channel.test.ts`, both driven through `FakeAdapter`'s ingress sink with explicit `operation.mentioned` (turn dedup keys off `logicalMessageId`/`revisionId`, so each turn gets its own id):

- `stays quiet in a conversation that never addressed it` — one non-mention turn, zero agent runs.
- `answers follow-ups once a mention subscribes that conversation` — mention in `c1`, follow-up in `c1`, unrelated non-mention in `c2`; exactly 2 runs.

Red-checked — with `app/channel.tsx` stashed, the second test fails, so it genuinely covers the new wiring:

```
=== WITHOUT the onMessage wiring ===
AssertionError: expected [ 'run' ] to have a length of 2 but got 1
      Tests  1 failed | 12 skipped (13)
```

With the change:

```
 Test Files  1 passed (1)
      Tests  1 passed | 12 skipped (13)
```

Runs are counted from inside the `FakeAgent` script, not from a field on the agent: every turn runs on a clone, and `FakeAgent.clone()` copies the remaining script but resets its own counters, so `CapturingAgent.calls` reads 0 even when the agent did run.

### Pre-existing red, unchanged by this PR

`pnpm check-types` and `pnpm test` are already failing on `main` from drift against `@copilotkit/channels@0.6.0` (`PlatformUser` no longer exported, `ProviderActor.kind` now required, `FakeAgent.clone()` resetting counters). Measured before and after:

| | `tsc` errors | Test files | Tests |
| --- | --- | --- | --- |
| baseline (`main`) | 20 | 3 failed / 17 passed | 9 failed / 130 passed (139) |
| this branch | 20 | 3 failed / 17 passed | 9 failed / 132 passed (141) |

The failing test names are byte-identical before and after (`diff` of the sorted failure list is empty), and no error is reported in `app/channel.tsx`. Fixing that drift is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)