### PR TITLE
docs: note the custom channel runner path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ OpenTag's channel can run two ways:
    and concurrency. Free plan available; this quick start uses it.
 2. **Your own channel runner** — build and operate one on the open-source
    Channels SDK. See the
-   [Channels SDK docs](https://docs.copilotkit.ai/channels) for what that
-   involves.
+   [Channels SDK docs](https://docs.copilotkit.ai/channels) for how to do
+   that.
 
 ### 1. Install dependencies
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ Prerequisites: Node.js 22+, pnpm, Python 3.12,
 [`uv`](https://docs.astral.sh/uv/), a CopilotKit account, an OpenAI API key,
 and a Slack workspace you can install an app into.
 
-OpenTag is built on the
-[CopilotKit Channels SDK](https://docs.copilotkit.ai/channels) — read the
-Channels docs for the full picture of how channels run. This quick start uses
-the managed Intelligence path, available on a free plan.
+OpenTag's channel can run two ways:
+
+1. **Managed channel runner** — an Enterprise Intelligence Channel runs the
+   connection and takes care of the durable-data concerns: delivery, state,
+   and concurrency. Free plan available; this quick start uses it.
+2. **Your own channel runner** — build and operate one on the open-source
+   Channels SDK. See the
+   [Channels SDK docs](https://docs.copilotkit.ai/channels) for what that
+   involves.
 
 ### 1. Install dependencies
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Prerequisites: Node.js 22+, pnpm, Python 3.12,
 [`uv`](https://docs.astral.sh/uv/), a CopilotKit account, an OpenAI API key,
 and a Slack workspace you can install an app into.
 
+OpenTag runs on a managed Intelligence Channel, available on a free plan. Like
+anything built on the [Channels SDK](https://docs.copilotkit.ai/channels), it
+can also run on your own channel runner — you implement the durable-data layer
+(state, concurrency, delivery) yourself. This quick start uses the managed
+path.
+
 ### 1. Install dependencies
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and a Slack workspace you can install an app into.
 
 OpenTag's channel can run two ways:
 
-1. **Managed channel runner** — an Enterprise Intelligence Channel runs the
+1. **Managed channel runner** — a CopilotKit Intelligence Channel runs the
    connection and takes care of the durable-data concerns: delivery, state,
    and concurrency. Free plan available; this quick start uses it.
 2. **Your own channel runner** — build and operate one on the open-source

--- a/README.md
+++ b/README.md
@@ -51,11 +51,10 @@ Prerequisites: Node.js 22+, pnpm, Python 3.12,
 [`uv`](https://docs.astral.sh/uv/), a CopilotKit account, an OpenAI API key,
 and a Slack workspace you can install an app into.
 
-OpenTag runs on a managed Intelligence Channel, available on a free plan. Like
-anything built on the [Channels SDK](https://docs.copilotkit.ai/channels), it
-can also run on your own channel runner — you implement the durable-data layer
-(state, concurrency, delivery) yourself. This quick start uses the managed
-path.
+OpenTag is built on the
+[CopilotKit Channels SDK](https://docs.copilotkit.ai/channels) — read the
+Channels docs for the full picture of how channels run. This quick start uses
+the managed Intelligence path, available on a free plan.
 
 ### 1. Install dependencies
 

--- a/setup.md
+++ b/setup.md
@@ -34,7 +34,8 @@ Prerequisites:
 - pnpm
 - Python 3.12
 - [`uv`](https://docs.astral.sh/uv/)
-- A CopilotKit Intelligence project, Channel, and runtime API key
+- A CopilotKit Intelligence project, Channel, and runtime API key (free plan
+  available)
 - An OpenAI API key for the Python agent
 
 ```bash

--- a/setup.md
+++ b/setup.md
@@ -35,7 +35,8 @@ Prerequisites:
 - Python 3.12
 - [`uv`](https://docs.astral.sh/uv/)
 - A CopilotKit Intelligence project, Channel, and runtime API key (free plan
-  available)
+  available) — or an alternative
+  [Channels SDK](https://docs.copilotkit.ai/channels) channel runner
 - An OpenAI API key for the Python agent
 
 ```bash


### PR DESCRIPTION
Companion to CopilotKit/CopilotKit#6437 (Channels docs pressure-release valve).

One short note in the quick start: OpenTag runs on a managed Intelligence Channel (free plan available), and — like anything built on the Channels SDK — it can also run on your own channel runner, with the durable-data layer (state, concurrency, delivery) implemented yourself. Plus a matching free-plan mention in setup.md.

Intentionally lightweight; no implementation guidance for custom runners.

Refs [FAC-155](https://linear.app/copilotkit/issue/FAC-155/channels-docs-lack-a-clear-supported-path-without-intelligence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)