### PR TITLE
feat(observability): add generic syslog log forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,13 @@ export OPENAI_API_KEY=sk-...              # Create a key at https://platform.ope
 # export OPENAI_REASONING_EFFORT=low
 # export OPENAI_VERBOSITY=low
 
+# -- Log Export (Optional; disabled by default) --
+# Configure these per process; use component=runtime for Node and agent for Python.
+# export OPENTAG_LOG_EXPORTER=syslog
+# export OPENTAG_LOG_EXPORTER_HOST=::1
+# export OPENTAG_LOG_EXPORTER_PORT=514
+# OPENTAG_LOG_COMPONENT is assigned automatically per bundled process.
+
 # -- Internal Sources (Optional) --
 # A fine-grained PAT with read access enables GitHub code, repo, issue, and PR search.
 # export GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_...

--- a/agent/log_exporter.py
+++ b/agent/log_exporter.py
@@ -1,0 +1,375 @@
+"""Best-effort duplication of process output to a generic syslog endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+import queue
+import re
+import socket
+import sys
+import threading
+from typing import Any, Literal, TextIO, cast
+
+
+MAX_DATAGRAM_BYTES = 8_192
+MAX_INCOMPLETE_BYTES = 65_536
+INCOMPLETE_FLUSH_BYTES = 8_000
+LogComponent = Literal["runtime", "agent"]
+StreamKind = Literal["stdout", "stderr"]
+
+
+@dataclass(frozen=True)
+class LogExporterHandle:
+    """Lifecycle handle returned by :func:`install_log_exporter`."""
+
+    enabled: bool
+    _close: Callable[[], None] = field(default=lambda: None, repr=False)
+
+    def close(self) -> None:
+        """Restore wrapped streams and release exporter resources."""
+        self._close()
+
+
+DISABLED_HANDLE = LogExporterHandle(enabled=False)
+
+
+@dataclass(frozen=True)
+class _Configuration:
+    host: str
+    port: int
+    component: LogComponent
+
+
+def _diagnose(stderr: TextIO, detail: str) -> None:
+    try:
+        stderr.write(f"[opentag] log exporter disabled: {detail}\n")
+    except Exception:
+        pass
+
+
+def _configuration(
+    environment: Mapping[str, str], stderr: TextIO
+) -> _Configuration | None:
+    exporter = environment.get("OPENTAG_LOG_EXPORTER", "none")
+    if exporter == "none":
+        return None
+    if exporter != "syslog":
+        _diagnose(stderr, f'invalid OPENTAG_LOG_EXPORTER "{exporter}"')
+        return None
+
+    host = environment.get("OPENTAG_LOG_EXPORTER_HOST", "").strip()
+    raw_port = environment.get("OPENTAG_LOG_EXPORTER_PORT", "")
+    component = environment.get("OPENTAG_LOG_COMPONENT", "")
+    try:
+        port = int(raw_port)
+        valid_port = 1 <= port <= 65535
+    except ValueError:
+        port = 0
+        valid_port = False
+    if not host or not valid_port or component not in {"runtime", "agent"}:
+        _diagnose(
+            stderr,
+            "syslog requires a host, a valid port, and component runtime|agent",
+        )
+        return None
+    return _Configuration(
+        host=host,
+        port=port,
+        component=cast(LogComponent, component),
+    )
+
+
+_TEXT_LEVEL = re.compile(
+    r"^\s*(?:\[\s*)?"
+    r"(emerg(?:ency)?|alert|fatal|crit(?:ical)?|err(?:or)?|warn(?:ing)?|"
+    r"notice|info(?:rmation)?|debug|trace)"
+    r"(?:\s*\])?(?=\s|:|-|$)",
+    re.IGNORECASE,
+)
+
+
+def _named_severity(value: str) -> int | None:
+    normalized = value.strip().lower()
+    if normalized in {"emerg", "emergency"}:
+        return 0
+    if normalized == "alert":
+        return 1
+    if normalized in {"fatal", "critical", "crit"}:
+        return 2
+    if normalized in {"error", "err"}:
+        return 3
+    if normalized in {"warn", "warning"}:
+        return 4
+    if normalized == "notice":
+        return 5
+    if normalized in {"info", "information"}:
+        return 6
+    if normalized in {"trace", "debug"}:
+        return 7
+    return None
+
+
+def _numeric_severity(value: float) -> int | None:
+    if value >= 60:
+        return 2
+    if value >= 50:
+        return 3
+    if value >= 40:
+        return 4
+    if value >= 30:
+        return 6
+    if value >= 0:
+        return 7
+    return None
+
+
+def _infer_severity(message: str, kind: StreamKind) -> int:
+    try:
+        parsed = json.loads(message)
+        if isinstance(parsed, dict):
+            for key in ("level", "severity", "severityText"):
+                value = parsed.get(key)
+                inferred = None
+                if isinstance(value, str):
+                    inferred = _named_severity(value)
+                elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                    inferred = _numeric_severity(value)
+                if inferred is not None:
+                    return inferred
+    except (TypeError, ValueError):
+        pass
+
+    match = _TEXT_LEVEL.match(message)
+    if match:
+        inferred = _named_severity(match.group(1))
+        if inferred is not None:
+            return inferred
+    return 6 if kind == "stdout" else 3
+
+
+def _take_utf8_prefix(value: str, max_bytes: int) -> tuple[str, str]:
+    bytes_used = 0
+    end = 0
+    for character in value:
+        character_bytes = len(character.encode())
+        if bytes_used + character_bytes > max_bytes:
+            break
+        bytes_used += character_bytes
+        end += len(character)
+    return value[:end], value[end:]
+
+
+def _frames(
+    message: str, kind: StreamKind, component: LogComponent
+) -> list[bytes]:
+    severity = _infer_severity(message, kind)
+    priority = 16 * 8 + severity
+    header = f"<{priority}>1 - - opentag-{component} - - - "
+    payload_bytes = MAX_DATAGRAM_BYTES - len(header.encode())
+    if not message:
+        return [header.encode()]
+
+    result = []
+    remaining = message
+    while remaining:
+        chunk, remaining = _take_utf8_prefix(remaining, payload_bytes)
+        result.append((header + chunk).encode())
+    return result
+
+
+class _Sender:
+    def __init__(self, datagram_socket: Any, configuration: _Configuration):
+        self._socket = datagram_socket
+        self._configuration = configuration
+        self._queue: queue.Queue[bytes | None] = queue.Queue(maxsize=1024)
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._run, name="opentag-log-exporter", daemon=True
+        )
+        self._thread.start()
+
+    def send(self, payload: bytes) -> None:
+        if self._closed:
+            return
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            pass
+
+    def _run(self) -> None:
+        while True:
+            payload = self._queue.get()
+            if payload is None:
+                return
+            try:
+                self._socket.sendto(
+                    payload,
+                    (self._configuration.host, self._configuration.port),
+                )
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+        try:
+            self._socket.close()
+        except Exception:
+            pass
+
+
+class _LineForwarder:
+    def __init__(
+        self, kind: StreamKind, component: LogComponent, sender: _Sender
+    ):
+        self._kind = kind
+        self._component = component
+        self._sender = sender
+        self._buffer = ""
+
+    def write(self, value: str) -> None:
+        self._buffer += value
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            for frame in _frames(line, self._kind, self._component):
+                self._sender.send(frame)
+        while len(self._buffer.encode()) > MAX_INCOMPLETE_BYTES:
+            chunk, self._buffer = _take_utf8_prefix(
+                self._buffer, INCOMPLETE_FLUSH_BYTES
+            )
+            for frame in _frames(chunk, self._kind, self._component):
+                self._sender.send(frame)
+
+
+class _StreamProxy:
+    def __init__(self, stream: TextIO, forwarder: _LineForwarder):
+        self._stream = stream
+        self._forwarder = forwarder
+
+    def write(self, value: str) -> int:
+        result = self._stream.write(value)
+        try:
+            self._forwarder.write(value)
+        except Exception:
+            pass
+        return result
+
+    def flush(self) -> None:
+        return self._stream.flush()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+def _rebind_logging_handlers(
+    original_stdout: TextIO,
+    original_stderr: TextIO,
+    stdout_proxy: _StreamProxy,
+    stderr_proxy: _StreamProxy,
+) -> list[tuple[logging.StreamHandler, TextIO]]:
+    loggers = [logging.getLogger()]
+    loggers.extend(
+        logger
+        for logger in logging.Logger.manager.loggerDict.values()
+        if isinstance(logger, logging.Logger)
+    )
+    rebound = []
+    seen = set()
+    for logger in loggers:
+        for handler in logger.handlers:
+            if not isinstance(handler, logging.StreamHandler) or id(handler) in seen:
+                continue
+            seen.add(id(handler))
+            if handler.stream is original_stdout:
+                try:
+                    handler.setStream(stdout_proxy)
+                    rebound.append((handler, original_stdout))
+                except Exception:
+                    pass
+            elif handler.stream is original_stderr:
+                try:
+                    handler.setStream(stderr_proxy)
+                    rebound.append((handler, original_stderr))
+                except Exception:
+                    pass
+    return rebound
+
+
+def install_log_exporter(
+    *,
+    env: Mapping[str, str] | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    socket_factory: Callable[[int, int], Any] = socket.socket,
+) -> LogExporterHandle:
+    """Install log forwarding when explicitly enabled by the environment."""
+    environment = os.environ if env is None else env
+    original_stdout = sys.stdout if stdout is None else stdout
+    original_stderr = sys.stderr if stderr is None else stderr
+    configuration = _configuration(environment, original_stderr)
+    if configuration is None:
+        return DISABLED_HANDLE
+
+    try:
+        datagram_socket = socket_factory(socket.AF_INET6, socket.SOCK_DGRAM)
+        datagram_socket.setblocking(False)
+    except Exception:
+        _diagnose(original_stderr, "could not create the IPv6 UDP socket")
+        return DISABLED_HANDLE
+
+    try:
+        sender = _Sender(datagram_socket, configuration)
+    except Exception:
+        try:
+            datagram_socket.close()
+        except Exception:
+            pass
+        _diagnose(original_stderr, "could not start the asynchronous sender")
+        return DISABLED_HANDLE
+    stdout_proxy = _StreamProxy(
+        original_stdout,
+        _LineForwarder("stdout", configuration.component, sender),
+    )
+    stderr_proxy = _StreamProxy(
+        original_stderr,
+        _LineForwarder("stderr", configuration.component, sender),
+    )
+    if sys.stdout is original_stdout:
+        sys.stdout = stdout_proxy  # type: ignore[assignment]
+    if sys.stderr is original_stderr:
+        sys.stderr = stderr_proxy  # type: ignore[assignment]
+    rebound_handlers = _rebind_logging_handlers(
+        original_stdout,
+        original_stderr,
+        stdout_proxy,
+        stderr_proxy,
+    )
+    closed = False
+
+    def close() -> None:
+        nonlocal closed
+        if closed:
+            return
+        closed = True
+        if sys.stdout is stdout_proxy:
+            sys.stdout = original_stdout
+        if sys.stderr is stderr_proxy:
+            sys.stderr = original_stderr
+        for handler, original_stream in rebound_handlers:
+            if handler.stream in {stdout_proxy, stderr_proxy}:
+                try:
+                    handler.setStream(original_stream)
+                except Exception:
+                    pass
+        sender.close()
+
+    return LogExporterHandle(enabled=True, _close=close)

--- a/agent/main.py
+++ b/agent/main.py
@@ -2,7 +2,17 @@
 
 from collections.abc import Mapping
 import os
+from pathlib import Path
 import sys
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from log_exporter import install_log_exporter  # noqa: E402
+
+_log_exporter_environment = {**os.environ, "OPENTAG_LOG_COMPONENT": "agent"}
+_log_exporter = install_log_exporter(env=_log_exporter_environment)
 
 from ag_ui_langgraph import add_langgraph_fastapi_endpoint
 from copilotkit import LangGraphAGUIAgent

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -24,6 +24,7 @@ packages = ["prompts"]
 py-modules = [
   "agent",
   "internal_sources",
+  "log_exporter",
   "main",
   "tools",
   "write_confirmation",

--- a/agent/tests/test_log_exporter.py
+++ b/agent/tests/test_log_exporter.py
@@ -1,0 +1,274 @@
+import io
+import logging
+import logging.config
+import re
+import socket as socket_module
+import sys
+import time
+
+from log_exporter import install_log_exporter
+from uvicorn.config import LOGGING_CONFIG
+
+
+class RecordingSocket:
+    def __init__(self):
+        self.datagrams = []
+        self.nonblocking = False
+        self.closed = False
+
+    def setblocking(self, value):
+        self.nonblocking = value is False
+
+    def sendto(self, payload, address):
+        self.datagrams.append((payload, address))
+
+    def close(self):
+        self.closed = True
+
+
+class FailingSocket(RecordingSocket):
+    def __init__(self):
+        super().__init__()
+        self.attempts = 0
+
+    def sendto(self, payload, address):
+        del payload, address
+        self.attempts += 1
+        raise OSError("network unavailable")
+
+
+def configured_environment():
+    return {
+        "OPENTAG_LOG_EXPORTER": "syslog",
+        "OPENTAG_LOG_EXPORTER_HOST": "::1",
+        "OPENTAG_LOG_EXPORTER_PORT": "5514",
+        "OPENTAG_LOG_COMPONENT": "agent",
+    }
+
+
+def wait_for_datagrams(recording_socket, count):
+    deadline = time.monotonic() + 1
+    while len(recording_socket.datagrams) < count and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert len(recording_socket.datagrams) >= count
+
+
+def test_disabled_exporter_is_a_true_no_op():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    handle = install_log_exporter(env={}, stdout=stdout, stderr=stderr)
+
+    assert handle.enabled is False
+    assert stdout.write("hello\n") == 6
+    assert stdout.getvalue() == "hello\n"
+    assert stderr.getvalue() == ""
+
+
+def test_preserves_streams_and_forwards_complete_lines_asynchronously(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    recording_socket = RecordingSocket()
+    socket_calls = []
+
+    def socket_factory(family, kind):
+        socket_calls.append((family, kind))
+        return recording_socket
+
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(), socket_factory=socket_factory
+    )
+
+    assert sys.stdout.write("hello\n") == 6
+    assert stdout.getvalue() == "hello\n"
+    wait_for_datagrams(recording_socket, 1)
+    assert recording_socket.datagrams == [
+        (b"<134>1 - - opentag-agent - - - hello", ("::1", 5514))
+    ]
+    assert socket_calls == [(socket_module.AF_INET6, socket_module.SOCK_DGRAM)]
+    assert recording_socket.nonblocking is True
+
+    handle.close()
+    assert sys.stdout is stdout
+    assert sys.stderr is stderr
+    assert recording_socket.closed is True
+
+
+def test_buffers_lines_and_infers_json_text_and_stream_severities(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    recording_socket = RecordingSocket()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(),
+        socket_factory=lambda _family, _kind: recording_socket,
+    )
+
+    sys.stdout.write('{"level":"debug","message":"π')
+    assert recording_socket.datagrams == []
+    sys.stdout.write('"}\n[WARNING] cuidado 🔥\n')
+    sys.stderr.write("plain failure\n")
+    wait_for_datagrams(recording_socket, 3)
+
+    assert [payload.decode() for payload, _address in recording_socket.datagrams] == [
+        '<135>1 - - opentag-agent - - - {"level":"debug","message":"π"}',
+        "<132>1 - - opentag-agent - - - [WARNING] cuidado 🔥",
+        "<131>1 - - opentag-agent - - - plain failure",
+    ]
+    handle.close()
+
+
+def test_bounds_incomplete_lines_and_splits_oversized_unicode_records(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    recording_socket = RecordingSocket()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(),
+        socket_factory=lambda _family, _kind: recording_socket,
+    )
+    message = "🔥" * 20_000
+
+    sys.stdout.write(message)
+    wait_for_datagrams(recording_socket, 1)
+    sys.stdout.write("\n")
+    wait_for_datagrams(recording_socket, 10)
+
+    payloads = [payload for payload, _address in recording_socket.datagrams]
+    assert all(len(payload) <= 8_192 for payload in payloads)
+    reconstructed = "".join(
+        re.sub(
+            r"^<\d+>1 - - opentag-agent - - - ",
+            "",
+            payload.decode(),
+        )
+        for payload in payloads
+    )
+    assert reconstructed == message
+    handle.close()
+
+
+def test_existing_standard_logging_handler_is_forwarded_once(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    recording_socket = RecordingSocket()
+    logger = logging.getLogger("opentag.tests.standard-logging")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(stderr)
+    logger.addHandler(handler)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(),
+        socket_factory=lambda _family, _kind: recording_socket,
+    )
+
+    logger.warning("dependency warning")
+    wait_for_datagrams(recording_socket, 1)
+
+    assert stderr.getvalue() == "dependency warning\n"
+    assert [payload.decode() for payload, _address in recording_socket.datagrams] == [
+        "<131>1 - - opentag-agent - - - dependency warning"
+    ]
+    handle.close()
+    logger.removeHandler(handler)
+    handler.close()
+
+
+def test_uvicorn_logging_handlers_are_forwarded_once(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    recording_socket = RecordingSocket()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(),
+        socket_factory=lambda _family, _kind: recording_socket,
+    )
+    logging.config.dictConfig(LOGGING_CONFIG)
+    logger = logging.getLogger("uvicorn.error")
+
+    logger.error("uvicorn failed")
+    wait_for_datagrams(recording_socket, 1)
+
+    assert "ERROR:" in stderr.getvalue()
+    assert "uvicorn failed" in stderr.getvalue()
+    payloads = [payload.decode() for payload, _address in recording_socket.datagrams]
+    assert len(payloads) == 1
+    assert payloads[0].startswith("<131>1 - - opentag-agent - - - ERROR:")
+    assert payloads[0].endswith("uvicorn failed")
+    handle.close()
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        configured_logger = logging.getLogger(name)
+        for handler in configured_logger.handlers:
+            handler.close()
+        configured_logger.handlers.clear()
+
+
+def test_invalid_configuration_emits_one_diagnostic_and_stays_disabled():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    socket_calls = []
+
+    handle = install_log_exporter(
+        env={"OPENTAG_LOG_EXPORTER": "syslog"},
+        stdout=stdout,
+        stderr=stderr,
+        socket_factory=lambda family, kind: socket_calls.append((family, kind)),
+    )
+
+    assert handle.enabled is False
+    assert socket_calls == []
+    assert re.fullmatch(
+        r"\[opentag\] log exporter disabled: .+\n", stderr.getvalue()
+    )
+
+
+def test_network_failures_never_change_application_writes(monkeypatch):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    failing_socket = FailingSocket()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    handle = install_log_exporter(
+        env=configured_environment(),
+        socket_factory=lambda _family, _kind: failing_socket,
+    )
+
+    assert sys.stdout.write("still local\n") == 12
+    deadline = time.monotonic() + 1
+    while failing_socket.attempts == 0 and time.monotonic() < deadline:
+        time.sleep(0.001)
+
+    assert failing_socket.attempts == 1
+    assert stdout.getvalue() == "still local\n"
+    assert stderr.getvalue() == ""
+    handle.close()
+
+
+def test_socket_creation_failure_disables_export_without_wrapping_streams():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    def fail_socket_creation(_family, _kind):
+        raise OSError("IPv6 unavailable")
+
+    handle = install_log_exporter(
+        env=configured_environment(),
+        stdout=stdout,
+        stderr=stderr,
+        socket_factory=fail_socket_creation,
+    )
+
+    assert handle.enabled is False
+    assert stdout.write("still local\n") == 12
+    assert stdout.getvalue() == "still local\n"
+    assert re.fullmatch(
+        r"\[opentag\] log exporter disabled: .+\n", stderr.getvalue()
+    )

--- a/app/env.test.ts
+++ b/app/env.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_INTELLIGENCE_GATEWAY_WS_URL,
   parsePort,
   readEnvironment,
+  readLogExporterEnvironment,
 } from "./env.js";
 
 const requiredEnvironment = {
@@ -79,4 +80,39 @@ describe("parsePort", () => {
       expect(() => parsePort(raw)).toThrow(`Invalid PORT: "${raw}"`);
     },
   );
+});
+
+describe("readLogExporterEnvironment", () => {
+  it("defaults to disabled", () => {
+    expect(readLogExporterEnvironment({})).toEqual({ exporter: "none" });
+  });
+
+  it("reads a complete syslog configuration", () => {
+    expect(
+      readLogExporterEnvironment({
+        OPENTAG_LOG_EXPORTER: "syslog",
+        OPENTAG_LOG_EXPORTER_HOST: "::1",
+        OPENTAG_LOG_EXPORTER_PORT: "5514",
+        OPENTAG_LOG_COMPONENT: "runtime",
+      }),
+    ).toEqual({
+      exporter: "syslog",
+      host: "::1",
+      port: 5514,
+      component: "runtime",
+    });
+  });
+
+  it.each([
+    { OPENTAG_LOG_EXPORTER: "unknown" },
+    { OPENTAG_LOG_EXPORTER: "syslog" },
+    {
+      OPENTAG_LOG_EXPORTER: "syslog",
+      OPENTAG_LOG_EXPORTER_HOST: "::1",
+      OPENTAG_LOG_EXPORTER_PORT: "0",
+      OPENTAG_LOG_COMPONENT: "runtime",
+    },
+  ])("reports invalid exporter configuration for %j", (env) => {
+    expect(readLogExporterEnvironment(env).exporter).toBe("invalid");
+  });
 });

--- a/app/env.ts
+++ b/app/env.ts
@@ -4,6 +4,18 @@ export const DEFAULT_INTELLIGENCE_GATEWAY_WS_URL =
   "wss://realtime.intelligence.copilotkit.ai";
 export const DEFAULT_INTELLIGENCE_CHANNEL_NAME = "open-tag";
 
+export type LogComponent = "runtime" | "agent";
+
+export type LogExporterEnvironment =
+  | { exporter: "none" }
+  | { exporter: "invalid"; detail: string }
+  | {
+      exporter: "syslog";
+      host: string;
+      port: number;
+      component: LogComponent;
+    };
+
 export interface AppEnvironment {
   agentUrl: string;
   agentAuthHeader?: string;
@@ -34,6 +46,40 @@ export function parsePort(
     throw new Error(`Invalid ${name}: "${raw}"`);
   }
   return port;
+}
+
+export function readLogExporterEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): LogExporterEnvironment {
+  const exporter = env.OPENTAG_LOG_EXPORTER ?? "none";
+  if (exporter === "none") return { exporter };
+  if (exporter !== "syslog") {
+    return {
+      exporter: "invalid",
+      detail: `invalid OPENTAG_LOG_EXPORTER "${exporter}"`,
+    };
+  }
+
+  const host = env.OPENTAG_LOG_EXPORTER_HOST?.trim();
+  const rawPort = env.OPENTAG_LOG_EXPORTER_PORT;
+  const port = Number(rawPort);
+  const component = env.OPENTAG_LOG_COMPONENT;
+  if (
+    !host ||
+    !rawPort ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65_535 ||
+    (component !== "runtime" && component !== "agent")
+  ) {
+    return {
+      exporter: "invalid",
+      detail:
+        "syslog requires a host, a valid port, and component runtime|agent",
+    };
+  }
+
+  return { exporter, host, port, component };
 }
 
 export function readEnvironment(

--- a/app/log-exporter-init.ts
+++ b/app/log-exporter-init.ts
@@ -1,0 +1,8 @@
+import "dotenv/config";
+import { installLogExporter } from "./log-exporter.js";
+
+// This module is imported before the runtime dependency graph so dependency
+// output is mirrored too. The default configuration leaves streams untouched.
+export const logExporter = installLogExporter({
+  env: { ...process.env, OPENTAG_LOG_COMPONENT: "runtime" },
+});

--- a/app/log-exporter.test.ts
+++ b/app/log-exporter.test.ts
@@ -1,0 +1,230 @@
+import type { Socket } from "node:dgram";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { installLogExporter } from "./log-exporter.js";
+
+class RecordingSocket extends EventEmitter {
+  readonly datagrams: Array<{ payload: Buffer; port: number; host: string }> = [];
+  unrefCalled = false;
+  closeCalled = false;
+
+  send(
+    payload: Uint8Array,
+    port: number,
+    host: string,
+    callback?: (error: Error | null) => void,
+  ): void {
+    this.datagrams.push({ payload: Buffer.from(payload), port, host });
+    callback?.(null);
+  }
+
+  unref(): this {
+    this.unrefCalled = true;
+    return this;
+  }
+
+  close(): this {
+    this.closeCalled = true;
+    return this;
+  }
+}
+
+function configuredEnvironment(): NodeJS.ProcessEnv {
+  return {
+    OPENTAG_LOG_EXPORTER: "syslog",
+    OPENTAG_LOG_EXPORTER_HOST: "::1",
+    OPENTAG_LOG_EXPORTER_PORT: "5514",
+    OPENTAG_LOG_COMPONENT: "runtime",
+  };
+}
+
+describe("installLogExporter", () => {
+  it("is a true no-op when log export is disabled", () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutWrite = stdout.write;
+    const stderrWrite = stderr.write;
+    const createSocket = vi.fn(() => {
+      throw new Error("must not create a socket");
+    });
+
+    const handle = installLogExporter({
+      env: {},
+      stdout,
+      stderr,
+      createSocket,
+    });
+
+    expect(handle.enabled).toBe(false);
+    expect(stdout.write).toBe(stdoutWrite);
+    expect(stderr.write).toBe(stderrWrite);
+    expect(createSocket).not.toHaveBeenCalled();
+  });
+
+  it("preserves stdout while forwarding complete records asynchronously", () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const socket = new RecordingSocket();
+    const createSocket = vi.fn(() => socket as unknown as Socket);
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr,
+      createSocket,
+    });
+
+    const writeResult = stdout.write("hello\n");
+
+    expect(writeResult).toBe(true);
+    expect(stdout.read()?.toString()).toBe("hello\n");
+    expect(socket.datagrams).toEqual([
+      {
+        payload: Buffer.from("<134>1 - - opentag-runtime - - - hello"),
+        port: 5514,
+        host: "::1",
+      },
+    ]);
+    expect(socket.unrefCalled).toBe(true);
+
+    handle.close();
+    expect(socket.closeCalled).toBe(true);
+  });
+
+  it("buffers partial lines and infers JSON, text, and stream severities", () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const socket = new RecordingSocket();
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr,
+      createSocket: () => socket as unknown as Socket,
+    });
+
+    stdout.write('{"level":"debug","message":"π');
+    expect(socket.datagrams).toHaveLength(0);
+    stdout.write('"}\n[WARN] cuidado 🔥\n');
+    stderr.write("plain failure\n");
+
+    expect(socket.datagrams.map(({ payload }) => payload.toString())).toEqual([
+      '<135>1 - - opentag-runtime - - - {"level":"debug","message":"π"}',
+      "<132>1 - - opentag-runtime - - - [WARN] cuidado 🔥",
+      "<131>1 - - opentag-runtime - - - plain failure",
+    ]);
+    handle.close();
+  });
+
+  it("bounds incomplete lines and splits oversized Unicode records", () => {
+    const stdout = new PassThrough();
+    const socket = new RecordingSocket();
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr: new PassThrough(),
+      createSocket: () => socket as unknown as Socket,
+    });
+    const message = "🔥".repeat(20_000);
+
+    stdout.write(message);
+    expect(socket.datagrams.length).toBeGreaterThan(0);
+    stdout.write("\n");
+
+    expect(socket.datagrams.every(({ payload }) => payload.length <= 8_192)).toBe(
+      true,
+    );
+    expect(
+      socket.datagrams
+        .map(({ payload }) =>
+          payload.toString().replace(/^<\d+>1 - - opentag-runtime - - - /, ""),
+        )
+        .join(""),
+    ).toBe(message);
+    handle.close();
+  });
+
+  it("preserves UTF-8 characters split across binary writes", () => {
+    const stdout = new PassThrough();
+    const socket = new RecordingSocket();
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr: new PassThrough(),
+      createSocket: () => socket as unknown as Socket,
+    });
+    const encoded = Buffer.from("hé🔥\n");
+
+    stdout.write(encoded.subarray(0, 4));
+    stdout.write(encoded.subarray(4));
+
+    expect(socket.datagrams[0]?.payload.toString()).toBe(
+      "<134>1 - - opentag-runtime - - - hé🔥",
+    );
+    handle.close();
+  });
+
+  it("disables invalid configuration after one local diagnostic", () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutWrite = stdout.write;
+    const stderrWrite = stderr.write;
+    const createSocket = vi.fn(() => new RecordingSocket() as unknown as Socket);
+
+    const handle = installLogExporter({
+      env: { OPENTAG_LOG_EXPORTER: "syslog" },
+      stdout,
+      stderr,
+      createSocket,
+    });
+
+    expect(handle.enabled).toBe(false);
+    expect(stdout.write).toBe(stdoutWrite);
+    expect(stderr.write).toBe(stderrWrite);
+    expect(createSocket).not.toHaveBeenCalled();
+    expect(stderr.read()?.toString()).toMatch(
+      /^\[opentag\] log exporter disabled: .+\n$/,
+    );
+  });
+
+  it("fails open when the IPv6 UDP socket cannot be created", () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutWrite = stdout.write;
+    const stderrWrite = stderr.write;
+
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr,
+      createSocket: () => {
+        throw new Error("IPv6 unavailable");
+      },
+    });
+
+    expect(handle.enabled).toBe(false);
+    expect(stdout.write).toBe(stdoutWrite);
+    expect(stderr.write).toBe(stderrWrite);
+    expect(stderr.read()?.toString()).toMatch(
+      /^\[opentag\] log exporter disabled: .+\n$/,
+    );
+  });
+
+  it("keeps stream backpressure and output unchanged when UDP sends fail", () => {
+    const stdout = new PassThrough({ highWaterMark: 1 });
+    const socket = new RecordingSocket();
+    socket.send = () => {
+      throw new Error("network unavailable");
+    };
+    const handle = installLogExporter({
+      env: configuredEnvironment(),
+      stdout,
+      stderr: new PassThrough(),
+      createSocket: () => socket as unknown as Socket,
+    });
+
+    expect(stdout.write("still local\n")).toBe(false);
+    expect(stdout.read()?.toString()).toBe("still local\n");
+    expect(() => stdout.write("still healthy\n")).not.toThrow();
+    handle.close();
+  });
+});

--- a/app/log-exporter.ts
+++ b/app/log-exporter.ts
@@ -1,0 +1,262 @@
+import { createSocket as createDatagramSocket, type Socket } from "node:dgram";
+import type { Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+import {
+  readLogExporterEnvironment,
+  type LogComponent,
+} from "./env.js";
+
+type StreamKind = "stdout" | "stderr";
+
+const MAX_DATAGRAM_BYTES = 8_192;
+const MAX_INCOMPLETE_BYTES = 65_536;
+const INCOMPLETE_FLUSH_BYTES = 8_000;
+
+export interface LogExporterHandle {
+  readonly enabled: boolean;
+  close(): void;
+}
+
+export interface InstallLogExporterOptions {
+  env?: NodeJS.ProcessEnv;
+  stdout?: Writable;
+  stderr?: Writable;
+  createSocket?: (type: "udp6") => Socket;
+}
+
+const DISABLED_HANDLE: LogExporterHandle = {
+  enabled: false,
+  close() {},
+};
+
+function reportConfigurationError(stderr: Writable, detail: string): void {
+  try {
+    stderr.write(`[opentag] log exporter disabled: ${detail}\n`);
+  } catch {
+    // Logging configuration must never affect application startup.
+  }
+}
+
+function namedSeverity(value: string): number | undefined {
+  switch (value.trim().toLowerCase()) {
+    case "emerg":
+    case "emergency":
+      return 0;
+    case "alert":
+      return 1;
+    case "fatal":
+    case "critical":
+    case "crit":
+      return 2;
+    case "error":
+    case "err":
+      return 3;
+    case "warn":
+    case "warning":
+      return 4;
+    case "notice":
+      return 5;
+    case "info":
+    case "information":
+      return 6;
+    case "trace":
+    case "debug":
+      return 7;
+    default:
+      return undefined;
+  }
+}
+
+function numericSeverity(value: number): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  if (value >= 60) return 2;
+  if (value >= 50) return 3;
+  if (value >= 40) return 4;
+  if (value >= 30) return 6;
+  if (value >= 0) return 7;
+  return undefined;
+}
+
+function inferSeverity(message: string, kind: StreamKind): number {
+  try {
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      for (const key of ["level", "severity", "severityText"]) {
+        const value = parsed[key];
+        const inferred =
+          typeof value === "string"
+            ? namedSeverity(value)
+            : typeof value === "number"
+              ? numericSeverity(value)
+              : undefined;
+        if (inferred !== undefined) return inferred;
+      }
+    }
+  } catch {
+    // Most log lines are plain text, not JSON.
+  }
+
+  const prefix = message.match(
+    /^\s*(?:\[\s*)?(emerg(?:ency)?|alert|fatal|crit(?:ical)?|err(?:or)?|warn(?:ing)?|notice|info(?:rmation)?|debug|trace)(?:\s*\])?(?=\s|:|-|$)/i,
+  )?.[1];
+  return (prefix ? namedSeverity(prefix) : undefined) ??
+    (kind === "stdout" ? 6 : 3);
+}
+
+function takeUtf8Prefix(value: string, maxBytes: number): [string, string] {
+  let bytes = 0;
+  let end = 0;
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character);
+    if (bytes + characterBytes > maxBytes) break;
+    bytes += characterBytes;
+    end += character.length;
+  }
+  return [value.slice(0, end), value.slice(end)];
+}
+
+function syslogFrames(
+  message: string,
+  kind: StreamKind,
+  component: LogComponent,
+): Buffer[] {
+  const severity = inferSeverity(message, kind);
+  const priority = 16 * 8 + severity;
+  const header = `<${priority}>1 - - opentag-${component} - - - `;
+  const payloadBytes = MAX_DATAGRAM_BYTES - Buffer.byteLength(header);
+  if (message.length === 0) return [Buffer.from(header, "utf8")];
+
+  const frames: Buffer[] = [];
+  let remaining = message;
+  while (remaining.length > 0) {
+    const [chunk, rest] = takeUtf8Prefix(remaining, payloadBytes);
+    frames.push(Buffer.from(header + chunk, "utf8"));
+    remaining = rest;
+  }
+  return frames;
+}
+
+function patchStream(
+  stream: Writable,
+  kind: StreamKind,
+  forward: (message: string, kind: StreamKind) => void,
+): () => void {
+  const originalWrite = stream.write;
+  let buffered = "";
+  let decoder = new StringDecoder("utf8");
+
+  const patchedWrite = function (this: Writable, ...args: unknown[]): boolean {
+    const result = Reflect.apply(originalWrite, stream, args) as boolean;
+    try {
+      const chunk = args[0];
+      if (typeof chunk === "string") {
+        buffered += decoder.end() + chunk;
+        decoder = new StringDecoder("utf8");
+      } else if (chunk instanceof Uint8Array) {
+        buffered += decoder.write(Buffer.from(chunk));
+      }
+
+      let newline = buffered.indexOf("\n");
+      while (newline >= 0) {
+        forward(buffered.slice(0, newline), kind);
+        buffered = buffered.slice(newline + 1);
+        newline = buffered.indexOf("\n");
+      }
+
+      while (Buffer.byteLength(buffered) > MAX_INCOMPLETE_BYTES) {
+        const [chunkToForward, rest] = takeUtf8Prefix(
+          buffered,
+          INCOMPLETE_FLUSH_BYTES,
+        );
+        forward(chunkToForward, kind);
+        buffered = rest;
+      }
+    } catch {
+      // Mirroring is best-effort and cannot change stream behavior.
+    }
+    return result;
+  };
+
+  stream.write = patchedWrite as typeof stream.write;
+  return () => {
+    if (stream.write === patchedWrite) stream.write = originalWrite;
+  };
+}
+
+export function installLogExporter(
+  options: InstallLogExporterOptions = {},
+): LogExporterHandle {
+  const env = options.env ?? process.env;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const configuration = readLogExporterEnvironment(env);
+  if (configuration.exporter === "none") return DISABLED_HANDLE;
+  if (configuration.exporter === "invalid") {
+    reportConfigurationError(stderr, configuration.detail);
+    return DISABLED_HANDLE;
+  }
+
+  let socket: Socket | undefined;
+  try {
+    socket = (options.createSocket ?? createDatagramSocket)("udp6");
+    socket.on("error", () => {});
+    socket.unref();
+  } catch {
+    try {
+      socket?.close();
+    } catch {
+      // Ignore cleanup failures on a partially initialized socket.
+    }
+    reportConfigurationError(stderr, "could not create the IPv6 UDP socket");
+    return DISABLED_HANDLE;
+  }
+
+  const activeSocket = socket;
+
+  const forward = (message: string, kind: StreamKind): void => {
+    for (const frame of syslogFrames(message, kind, configuration.component)) {
+      try {
+        activeSocket.send(
+          frame,
+          configuration.port,
+          configuration.host,
+          () => {},
+        );
+      } catch {
+        // Network failures are intentionally silent and fail open.
+      }
+    }
+  };
+  let restoreStdout = (): void => {};
+  let restoreStderr = (): void => {};
+  try {
+    restoreStdout = patchStream(stdout, "stdout", forward);
+    restoreStderr = patchStream(stderr, "stderr", forward);
+  } catch {
+    restoreStdout();
+    restoreStderr();
+    try {
+      activeSocket.close();
+    } catch {
+      // Ignore cleanup failures on a partially initialized exporter.
+    }
+    reportConfigurationError(stderr, "could not wrap process output");
+    return DISABLED_HANDLE;
+  }
+  let closed = false;
+
+  return {
+    enabled: true,
+    close() {
+      if (closed) return;
+      closed = true;
+      restoreStdout();
+      restoreStderr();
+      try {
+        activeSocket.close();
+      } catch {
+        // Closing a failed or already-closed socket is harmless.
+      }
+    },
+  };
+}

--- a/app/runtime-host.test.ts
+++ b/app/runtime-host.test.ts
@@ -52,7 +52,7 @@ describe("createOpenTagRuntime", () => {
 
     expect(listener.channels).toBeDefined();
     await listener.channels?.ready({ timeoutMs: 500 });
-    expect(listener.channels?.status()).toEqual({
+    expect(listener.channels?.status()).toMatchObject({
       overall: "online",
       channels: {
         "open-tag": "online",

--- a/app/server.test.ts
+++ b/app/server.test.ts
@@ -36,6 +36,7 @@ function makeControls(overrides: Partial<ChannelsControl> = {}) {
     status: vi.fn(() => ({
       overall: "online" as const,
       channels: { opentag: "online" as const },
+      detail: {},
     })),
     stop: vi.fn(async () => undefined),
     ...overrides,

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "./app/log-exporter-init.js";
 import {
   createServer,
   type RequestListener,

--- a/setup.md
+++ b/setup.md
@@ -137,6 +137,20 @@ Note that `ready()` resolving is not proof of health. It also resolves on
 `/api/copilotkit/info` returning 200 reports license and runtime state while
 saying nothing at all about Slack.
 
+### Log export
+
+Log export is provider-neutral and disabled by default. Set
+`OPENTAG_LOG_EXPORTER=syslog` together with `OPENTAG_LOG_EXPORTER_HOST`,
+`OPENTAG_LOG_EXPORTER_PORT`, and `OPENTAG_LOG_COMPONENT` (`runtime` or `agent`)
+to duplicate that process's existing stdout and stderr over IPv6 UDP syslog.
+The bundled entrypoints assign `OPENTAG_LOG_COMPONENT` automatically (`runtime`
+for Node and `agent` for Python), so the shared root `.env` should configure
+only the exporter, host, and port. Custom installers must supply the component.
+
+Forwarding is best-effort: local output remains unchanged, and invalid
+configuration or network failures never block startup, health checks, writes,
+or shutdown. Leaving `OPENTAG_LOG_EXPORTER` unset is equivalent to `none`.
+
 ## Channel reference
 
 The Channel is created and reconciled with the public CopilotKit CLI. These


### PR DESCRIPTION
## Summary

- add equivalent built-in TypeScript and Python exporters that duplicate existing stdout/stderr records to IPv6 UDP syslog
- install forwarding before runtime and agent dependency imports while keeping it disabled by default and fully fail-open
- infer common JSON/text severities, bound partial lines, split oversized UTF-8 messages, and preserve local stream behavior
- document the provider-neutral environment contract and add focused conformance/failure tests, including real Uvicorn logging configuration

No Datadog, Railway IaC, deployment, credential, or environment changes are included.

Two existing Channels status assertions were updated for the `detail` field returned by the pinned runtime so the repository's required type and test checks remain green.

## Validation

- `pnpm check-types`
- `pnpm test` — 175 passed
- `(cd agent && uv run pytest)` — 79 passed
- `node node_modules/railway/dist/iac/bin.js` — evaluation successful with no diagnostics
