### PR TITLE
docs: add an About section framing OpenTag as a Channels SDK starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ already is.
 
 </div>
 
-## The complete Channels SDK application
+## The Channels SDK starter application
 
 [Channels SDK](https://github.com/CopilotKit/channels-sdk) brings any AG-UI agent
 into Slack and Microsoft Teams. Its README shows you the pieces. **OpenTag is

--- a/README.md
+++ b/README.md
@@ -391,6 +391,41 @@ The Slack live harness is documented in [`e2e/README.md`](./e2e/README.md).
 | Connect an agent in another framework | [AG-UI integrations](https://docs.ag-ui.com/introduction) |
 | Cut production `@kite` over to OpenTag | [`docs/migration-kite.md`](./docs/migration-kite.md) |
 
+## About
+
+OpenTag is built and maintained by [CopilotKit](https://www.copilotkit.ai) —
+the team behind the [Channels SDK](https://github.com/CopilotKit/channels-sdk)
+and the [AG-UI protocol](https://github.com/ag-ui-protocol/ag-ui).
+
+It is a **starter project for the Channels SDK**. The SDK's own README shows
+each piece on its own; OpenTag is those pieces assembled into an application
+worth deploying, published so you can start from a working system instead of a
+blank directory. Nothing here is meant to stay the way we wrote it — fork it,
+swap the agent, the persona, the tools, and the UI, and ship it under your own
+name. We keep it aligned with the SDK so a fork stays upgradeable.
+
+Two adjacent things, so the boundary stays clear:
+
+- The **[Channels SDK](https://github.com/CopilotKit/channels-sdk)**
+  (`@copilotkit/channels`) is the open-source library that gives an
+  AG-UI-compatible agent a native place to work in Slack and Microsoft Teams.
+  OpenTag is one application built on it.
+- **[CopilotKit Intelligence](https://docs.copilotkit.ai/channels)** is the
+  managed service that runs the platform connection and the durable-data
+  concerns behind it. This quick start uses it, and it is optional — you can
+  operate your own channel runner instead.
+
+Questions, forks worth showing off, and bug reports are all welcome:
+
+- [Discord](https://discord.gg/6dffbvGU3D) — ask a question or show what you
+  built
+- [@copilotkit on X](https://x.com/copilotkit) — releases and what's shipping
+- [docs.copilotkit.ai](https://docs.copilotkit.ai) — CopilotKit and Channels
+  documentation
+- [OpenTag issues](https://github.com/CopilotKit/OpenTag/issues) for this
+  repository, [channels-sdk issues](https://github.com/CopilotKit/channels-sdk/issues)
+  for the SDK underneath it
+
 ## License
 
 [MIT](./LICENSE) © CopilotKit


### PR DESCRIPTION
The README explains what OpenTag does and how to fork it, but never says who
publishes it, that it exists as a starter project for the Channels SDK, or where
to go with a question. This adds an About section above the license.

## What it says

- CopilotKit builds and maintains it — the team behind the Channels SDK and
  AG-UI.
- OpenTag is a **starter project for the Channels SDK**: the SDK README shows the
  pieces on their own, OpenTag is those pieces assembled and deployable,
  published so a fork starts from a working system. Kept aligned with the SDK so
  forks stay upgradeable.
- Restates the one distinction the rest of the README already warns is easy to
  confuse: `@copilotkit/channels` is the open-source library; CopilotKit
  Intelligence is the optional managed connection.
- Where to reach us: Discord, @copilotkit on X, docs, and separate issue
  trackers for the app vs. the SDK.

## Link provenance

No invented URLs. The Discord invite and X handle are the ones in
`CopilotKit/CopilotKit`'s README; the copilotkit.ai, AG-UI, and Channels SDK
links are the ones `channels-sdk`'s README publishes.

## Not included, deliberately

- No `Contributing` line — the repo has no CONTRIBUTING.md, so forks are pointed
  at issues instead.
- No security-reporting line — #5 is already open for that.
- Also renames the section heading above from "The complete Channels SDK
  application" to "The Channels SDK starter application" — the two framings
  contradicted each other, and starter is the accurate one. Nothing linked to
  the old anchor.
- Header nav (line 7) left unchanged; adding **About** to it is a one-liner if
  reviewers want it.

README-only, no code paths touched.

