### PR TITLE
feat: add conditional thread subscription tools

### DIFF
--- a/app/channel-helpers.test.ts
+++ b/app/channel-helpers.test.ts
@@ -1,4 +1,8 @@
-import type { AgentContentPart, IncomingMessage } from "@copilotkit/channels";
+import type {
+  AgentContentPart,
+  ChannelTool,
+  IncomingMessage,
+} from "@copilotkit/channels";
 import { describe, expect, it } from "vitest";
 import {
   defaultSlackContext,
@@ -67,5 +71,22 @@ describe("managedRunInput", () => {
         },
       ],
     });
+  });
+
+  it("merges conditional tools after Slack defaults", () => {
+    const conditionalTool = { name: "conditional" } as ChannelTool;
+
+    expect(managedRunInput(message(), [conditionalTool]).tools).toEqual([
+      ...defaultSlackTools,
+      conditionalTool,
+    ]);
+  });
+
+  it("adds conditional tools to Teams without adding Slack defaults", () => {
+    const conditionalTool = { name: "conditional" } as ChannelTool;
+
+    expect(
+      managedRunInput(message({ platform: "teams" }), [conditionalTool]).tools,
+    ).toEqual([conditionalTool]);
   });
 });

--- a/app/channel-helpers.ts
+++ b/app/channel-helpers.ts
@@ -25,24 +25,32 @@ export function promptFromMessage(
  * Add only the source platform's defaults. Intelligence is the transport;
  * `message.platform` is the originating provider (`slack` or `teams`).
  */
-export function managedRunInput(message: IncomingMessage) {
+export function managedRunInput(
+  message: IncomingMessage,
+  conditionalTools: ChannelTool[] = [],
+) {
   return {
     prompt: promptFromMessage(message),
-    ...platformRunInput(message.platform, message.actor),
+    ...platformRunInput(message.platform, message.actor, conditionalTools),
   };
 }
 
 export function platformRunInput(
   platform: string,
   actor: ProviderActor | undefined,
+  conditionalTools: ChannelTool[] = [],
 ): {
   tools?: ChannelTool[];
   context: ContextEntry[];
 } {
   const slack = platform === "slack";
+  const tools = [
+    ...(slack ? defaultSlackTools : []),
+    ...conditionalTools,
+  ];
 
   return {
-    ...(slack ? { tools: [...defaultSlackTools] } : {}),
+    ...(tools.length > 0 ? { tools } : {}),
     context: [
       ...(slack ? defaultSlackContext : []),
       ...senderContext(actor, platform),

--- a/app/channel.test.ts
+++ b/app/channel.test.ts
@@ -21,6 +21,10 @@ import { appContext } from "./context/app-context.js";
 import { appTools } from "./tools/index.js";
 import { RenderChart } from "./tools/render-chart.js";
 import { createOpenTagChannel } from "./channel.js";
+import {
+  subscribeThreadTool,
+  unsubscribeThreadTool,
+} from "./tools/thread-subscription.js";
 
 class CapturingAgent extends FakeAgent {
   readonly calls: Array<RunAgentParameters | undefined>;
@@ -52,6 +56,50 @@ class CapturingAgent extends FakeAgent {
     this.messageSnapshots.push(structuredClone(this.messages));
     return super.runAgent(parameters, subscriber);
   }
+}
+
+type AgentStep = (subscriber: AgentSubscriber) => void | Promise<void>;
+
+class SharedScriptAgent extends FakeAgent {
+  constructor(
+    private readonly steps: AgentStep[],
+    readonly calls: Array<RunAgentParameters | undefined> = [],
+  ) {
+    super();
+  }
+
+  override clone(): SharedScriptAgent {
+    const cloned = new SharedScriptAgent(this.steps, this.calls);
+    cloned.threadId = this.threadId;
+    cloned.agentId = this.agentId;
+    cloned.messages = structuredClone(this.messages);
+    cloned.state = structuredClone(this.state);
+    return cloned;
+  }
+
+  override async runAgent(
+    parameters?: RunAgentParameters,
+    subscriber?: AgentSubscriber,
+  ): Promise<RunAgentResult> {
+    this.calls.push(parameters);
+    const step = this.steps.shift();
+    if (step && subscriber) await step(subscriber);
+    return { result: undefined, newMessages: [] };
+  }
+}
+
+function callTool(name: string, id: string): AgentStep {
+  return (subscriber) => {
+    subscriber.onToolCallEndEvent?.({
+      event: { toolCallId: id },
+      toolCallName: name,
+      toolCallArgs: {},
+    } as never);
+  };
+}
+
+function toolNames(call: RunAgentParameters | undefined): string[] {
+  return call?.tools?.map(({ name }) => name) ?? [];
 }
 
 const channels: Channel[] = [];
@@ -142,7 +190,7 @@ function makeChannel(options: { agent?: FakeAgent } = {}) {
 }
 
 describe("createOpenTagChannel", () => {
-  it("subscribes when Kite is mentioned and handles a later managed delivery", async () => {
+  it("subscribes a new mentioned conversation and handles a later managed delivery", async () => {
     const { adapter, agent, channel, stateStore } = makeChannel();
 
     await channel.ɵruntime.start();
@@ -160,6 +208,12 @@ describe("createOpenTagChannel", () => {
       },
     });
     expect(await stateStore.kv.get<boolean>("sub:mentioned-thread")).toBe(true);
+    expect(toolNames((agent as CapturingAgent).calls[0])).toContain(
+      unsubscribeThreadTool.name,
+    );
+    expect(toolNames((agent as CapturingAgent).calls[0])).not.toContain(
+      subscribeThreadTool.name,
+    );
 
     await adapter.getSink().onTurn({
       conversationKey: "mentioned-thread",
@@ -176,6 +230,185 @@ describe("createOpenTagChannel", () => {
     });
 
     expect((agent as CapturingAgent).calls).toHaveLength(2);
+    expect(toolNames((agent as CapturingAgent).calls[1])).toContain(
+      unsubscribeThreadTool.name,
+    );
+  });
+
+  it("keeps an existing unsubscribed conversation mention-only and offers subscribe", async () => {
+    const { adapter, agent, channel, stateStore } = makeChannel();
+    adapter.messages = [
+      { text: "existing root", ts: "1" },
+      { text: "@Kite answer this", ts: "2" },
+    ];
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "existing-thread",
+      replyTarget: {},
+      userText: "@Kite answer this",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m2",
+        revisionId: "m2",
+        mentioned: true,
+      },
+    });
+
+    expect(await stateStore.kv.get<boolean>("sub:existing-thread")).toBeUndefined();
+    expect(toolNames((agent as CapturingAgent).calls[0])).toContain(
+      subscribeThreadTool.name,
+    );
+    expect(toolNames((agent as CapturingAgent).calls[0])).not.toContain(
+      unsubscribeThreadTool.name,
+    );
+  });
+
+  it("offers unsubscribe on a mention in an already subscribed conversation", async () => {
+    const { adapter, agent, channel, stateStore } = makeChannel();
+    await stateStore.kv.set("sub:subscribed-thread", true);
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "subscribed-thread",
+      replyTarget: {},
+      userText: "@Kite status?",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m2",
+        revisionId: "m2",
+        mentioned: true,
+      },
+    });
+
+    expect(toolNames((agent as CapturingAgent).calls[0])).toContain(
+      unsubscribeThreadTool.name,
+    );
+    expect(toolNames((agent as CapturingAgent).calls[0])).not.toContain(
+      subscribeThreadTool.name,
+    );
+  });
+
+  it("falls back to a new conversation when history loading fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { adapter, agent, channel, stateStore } = makeChannel();
+    adapter.getMessages = vi.fn(async () => {
+      throw new Error("history unavailable");
+    });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "history-failure",
+      replyTarget: {},
+      userText: "@Kite help",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m1",
+        revisionId: "m1",
+        mentioned: true,
+      },
+    });
+
+    expect(await stateStore.kv.get<boolean>("sub:history-failure")).toBe(true);
+    expect(toolNames((agent as CapturingAgent).calls[0])).toContain(
+      unsubscribeThreadTool.name,
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[channel] recoverable error",
+      expect.objectContaining({
+        context: {
+          operation: "get_thread_history",
+          recovery: "treat_as_new_conversation",
+        },
+      }),
+    );
+  });
+
+  it("ignores unmentioned turns after unsubscribe and resumes them after subscribe", async () => {
+    const agent = new SharedScriptAgent([
+      callTool(unsubscribeThreadTool.name, "unsubscribe-1"),
+      () => undefined,
+      callTool(subscribeThreadTool.name, "subscribe-1"),
+      () => undefined,
+      () => undefined,
+    ]);
+    const { adapter, channel, stateStore } = makeChannel({ agent });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "toggle-thread",
+      replyTarget: {},
+      userText: "@Kite only answer mentions from now on",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m1",
+        revisionId: "m1",
+        mentioned: true,
+      },
+    });
+    expect(await stateStore.kv.get<boolean>("sub:toggle-thread")).toBeUndefined();
+    expect(toolNames(agent.calls[0])).toContain(unsubscribeThreadTool.name);
+
+    await adapter.getSink().onTurn({
+      conversationKey: "toggle-thread",
+      replyTarget: {},
+      userText: "this should be ignored",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m2",
+        revisionId: "m2",
+        mentioned: false,
+      },
+    });
+    expect(agent.calls).toHaveLength(2);
+
+    adapter.messages = [
+      { text: "existing root", ts: "1" },
+      { text: "@Kite start following again", ts: "3" },
+    ];
+    await adapter.getSink().onTurn({
+      conversationKey: "toggle-thread",
+      replyTarget: {},
+      userText: "@Kite start following again",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m3",
+        revisionId: "m3",
+        mentioned: true,
+      },
+    });
+    expect(await stateStore.kv.get<boolean>("sub:toggle-thread")).toBe(true);
+    expect(toolNames(agent.calls[2])).toContain(subscribeThreadTool.name);
+
+    await adapter.getSink().onTurn({
+      conversationKey: "toggle-thread",
+      replyTarget: {},
+      userText: "this should run",
+      platform: "slack",
+      actor: { id: "U1", kind: "human" },
+      operation: {
+        kind: "created",
+        logicalMessageId: "m4",
+        revisionId: "m4",
+        mentioned: false,
+      },
+    });
+    expect(agent.calls).toHaveLength(5);
+    expect(toolNames(agent.calls[4])).toContain(unsubscribeThreadTool.name);
   });
 
   it.each(["bot", "app"] as const)(
@@ -209,6 +442,20 @@ describe("createOpenTagChannel", () => {
           logicalMessageId: "m2",
           revisionId: "m2",
           mentioned: false,
+        },
+      });
+
+      await adapter.getSink().onTurn({
+        conversationKey: "bot-loop-thread",
+        replyTarget: {},
+        userText: "@Kite automated follow-up",
+        platform: "slack",
+        actor: { id: "B1", kind: actorKind },
+        operation: {
+          kind: "created",
+          logicalMessageId: "m3",
+          revisionId: "m3",
+          mentioned: true,
         },
       });
 
@@ -332,6 +579,7 @@ describe("createOpenTagChannel", () => {
         ...appTools.map(({ name }) => name),
         RenderChart.name,
         ...defaultSlackTools.map(({ name }) => name),
+        unsubscribeThreadTool.name,
       ].sort(),
     );
     expect(call?.context).toEqual([
@@ -358,7 +606,11 @@ describe("createOpenTagChannel", () => {
 
     const call = (agent as CapturingAgent).calls[0];
     expect(call?.tools?.map(({ name }) => name).sort()).toEqual(
-      [...appTools.map(({ name }) => name), RenderChart.name].sort(),
+      [
+        ...appTools.map(({ name }) => name),
+        RenderChart.name,
+        unsubscribeThreadTool.name,
+      ].sort(),
     );
     expect(call?.context).toEqual([
       ...appContext,

--- a/app/channel.tsx
+++ b/app/channel.tsx
@@ -1,6 +1,7 @@
 import {
   createChannel,
   type Channel,
+  type ChannelTool,
   type CreateChannelOptions,
 } from "@copilotkit/channels";
 import { managedRunInput, reportRecoverableError } from "./channel-helpers.js";
@@ -13,6 +14,10 @@ import { FILE_ISSUE_CALLBACK, fileIssueSubmit } from "./modals/file-issue.js";
 import { IncidentCard } from "./tools/showcase-tools.js";
 import { RenderChart } from "./tools/render-chart.js";
 import { appTools } from "./tools/index.js";
+import {
+  subscribeThreadTool,
+  unsubscribeThreadTool,
+} from "./tools/thread-subscription.js";
 
 type ChannelAgent = NonNullable<CreateChannelOptions["agent"]>;
 
@@ -38,12 +43,16 @@ export function createOpenTagChannel(
     ],
   });
 
-  const runAgentSafely: Parameters<typeof channel.onMessage>[0] = async ({
-    thread,
-    message,
-  }) => {
+  type MessageHandlerInput = Parameters<
+    Parameters<typeof channel.onMessage>[0]
+  >[0];
+
+  const runAgentSafely = async (
+    { thread, message }: MessageHandlerInput,
+    conditionalTools: ChannelTool[],
+  ) => {
     try {
-      await thread.runAgent(managedRunInput(message));
+      await thread.runAgent(managedRunInput(message, conditionalTools));
     } catch (error) {
       try {
         await thread.post(
@@ -66,15 +75,38 @@ export function createOpenTagChannel(
   };
 
   channel.onMention(async ({ thread, message }) => {
-    await thread.subscribe();
-    await runAgentSafely({ thread, message });
+    if (message.actor.kind === "bot" || message.actor.kind === "app") return;
+
+    if (await thread.isSubscribed()) {
+      await runAgentSafely({ thread, message }, [unsubscribeThreadTool]);
+      return;
+    }
+
+    let isNewConversation = true;
+    try {
+      const history = await thread.getMessages();
+      isNewConversation = !history || history.length <= 1;
+    } catch (error) {
+      reportRecoverableError(error, {
+        operation: "get_thread_history",
+        recovery: "treat_as_new_conversation",
+      });
+    }
+
+    if (isNewConversation) {
+      await thread.subscribe();
+      await runAgentSafely({ thread, message }, [unsubscribeThreadTool]);
+      return;
+    }
+
+    await runAgentSafely({ thread, message }, [subscribeThreadTool]);
   });
 
   channel.onMessage(async ({ thread, message }) => {
     if (message.actor.kind === "bot" || message.actor.kind === "app") return;
 
     if (await thread.isSubscribed()) {
-      await runAgentSafely({ thread, message });
+      await runAgentSafely({ thread, message }, [unsubscribeThreadTool]);
     }
   });
 

--- a/app/tools/__tests__/thread-subscription.test.ts
+++ b/app/tools/__tests__/thread-subscription.test.ts
@@ -1,0 +1,60 @@
+import type { ChannelToolContext } from "@copilotkit/channels";
+import { describe, expect, it, vi } from "vitest";
+import {
+  subscribeThreadTool,
+  unsubscribeThreadTool,
+} from "../thread-subscription.js";
+
+function makeContext() {
+  const thread = {
+    subscribe: vi.fn(async () => undefined),
+    unsubscribe: vi.fn(async () => undefined),
+  };
+
+  return {
+    thread,
+    context: { thread } as unknown as ChannelToolContext,
+  };
+}
+
+describe("thread subscription tools", () => {
+  it("unsubscribes the current thread and returns a concise confirmation", async () => {
+    const { thread, context } = makeContext();
+
+    expect(unsubscribeThreadTool.name).toBe("unsubscribe_thread");
+    expect(unsubscribeThreadTool.description).toMatch(/clearly and explicitly/i);
+    expect(unsubscribeThreadTool.description).toMatch(/ordinary questions/i);
+    expect(unsubscribeThreadTool.description).toMatch(/criticism/i);
+    expect(unsubscribeThreadTool.description).toMatch(/temporary pauses/i);
+    expect(unsubscribeThreadTool.parameters.safeParse({}).success).toBe(true);
+    expect(
+      unsubscribeThreadTool.parameters.safeParse({ reason: "quiet" }).data,
+    ).toEqual({});
+
+    await expect(unsubscribeThreadTool.handler({}, context)).resolves.toBe(
+      "This thread is now mention-only; future replies require a mention.",
+    );
+    expect(thread.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(thread.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("subscribes the current thread and returns a concise confirmation", async () => {
+    const { thread, context } = makeContext();
+
+    expect(subscribeThreadTool.name).toBe("subscribe_thread");
+    expect(subscribeThreadTool.description).toMatch(/clearly and explicitly/i);
+    expect(subscribeThreadTool.description).toMatch(/ordinary questions/i);
+    expect(subscribeThreadTool.description).toMatch(/criticism/i);
+    expect(subscribeThreadTool.description).toMatch(/temporary pauses/i);
+    expect(subscribeThreadTool.parameters.safeParse({}).success).toBe(true);
+    expect(
+      subscribeThreadTool.parameters.safeParse({ reason: "resume" }).data,
+    ).toEqual({});
+
+    await expect(subscribeThreadTool.handler({}, context)).resolves.toBe(
+      "This thread is subscribed; future human messages may receive replies without mentions.",
+    );
+    expect(thread.subscribe).toHaveBeenCalledTimes(1);
+    expect(thread.unsubscribe).not.toHaveBeenCalled();
+  });
+});

--- a/app/tools/thread-subscription.ts
+++ b/app/tools/thread-subscription.ts
@@ -1,0 +1,30 @@
+import { defineChannelTool } from "@copilotkit/channels";
+import { z } from "zod";
+
+export const unsubscribeThreadTool = defineChannelTool({
+  name: "unsubscribe_thread",
+  description:
+    "Call only when a user clearly and explicitly asks to stop automatic " +
+    "replies to future messages in this thread unless the agent is mentioned. " +
+    "Ordinary questions, criticism, temporary pauses, and requests to stop or " +
+    "pause only the current task do not qualify.",
+  parameters: z.object({}),
+  async handler(_args, { thread }) {
+    await thread.unsubscribe();
+    return "This thread is now mention-only; future replies require a mention.";
+  },
+});
+
+export const subscribeThreadTool = defineChannelTool({
+  name: "subscribe_thread",
+  description:
+    "Call only when a user clearly and explicitly asks to resume automatic " +
+    "replies to future human messages in this thread without requiring a " +
+    "mention. Ordinary questions, criticism, temporary pauses, and requests " +
+    "to continue only the current task do not qualify.",
+  parameters: z.object({}),
+  async handler(_args, { thread }) {
+    await thread.subscribe();
+    return "This thread is subscribed; future human messages may receive replies without mentions.";
+  },
+});


### PR DESCRIPTION
## Summary

- add explicit `unsubscribe_thread` and `subscribe_thread` Channel tools with strict invocation guidance
- conditionally offer the correct tool based on authoritative thread subscription state and conversation history
- preserve Slack default-tool merging, Teams behavior, and bot/app filtering
- add coverage for new versus existing threads, history fallback, and unsubscribe/resubscribe routing

## Verification

- `pnpm check-types`
- `pnpm test` (178 passed)
- `(cd agent && uv run pytest)` (72 passed)
- `node node_modules/railway/dist/iac/bin.js`

The optional live Channel smoke test was not run because local Intelligence credentials are not present in this workspace.