### PR TITLE
fix(ci): use GitHub App client ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         if: inputs.dry_run != true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: 1108748
+          client-id: ${{ vars.DEVOPS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
           owner: CopilotKit
           repositories: OpenTag

--- a/docs/kite-gitops.md
+++ b/docs/kite-gitops.md
@@ -18,9 +18,10 @@ but deploy independently.
 - Rollback: run **Kite / Deploy released version** → select environment and `vX.Y.Z` →
   deploy the digests recorded in that release.
 
-The release PR uses CopilotKit's DevOps GitHub App (app ID `1108748`). Grant the
-App access to OpenTag and make the existing `DEVOPS_BOT_PRIVATE_KEY`
-organization secret available to this repository.
+The release PR uses CopilotKit's DevOps GitHub App. Grant the App access to
+OpenTag, store its client ID as the `DEVOPS_BOT_CLIENT_ID` repository variable,
+and make the `DEVOPS_BOT_PRIVATE_KEY` Actions secret available to this
+repository.
 
 ## One-time AWS trust
 


### PR DESCRIPTION
## Summary
- use the DevOps GitHub App client ID required by create-github-app-token v3
- document the repository variable and private-key secret contract

## Verification
- actionlint .github/workflows/*.yml
- git diff --check

The DEVOPS_BOT_CLIENT_ID repository variable is configured. DEVOPS_BOT_PRIVATE_KEY still needs to be made available as a repository or organization Actions secret.