### PR TITLE
feat: configure an Intelligence Learning Container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ export OPENAI_API_KEY=sk-...              # Create a key at https://platform.ope
 # export AGENT_AUTH_HEADER="Bearer ..."   # Forwarded to an agent that requires authentication.
 # export INTELLIGENCE_API_URL=https://api.intelligence.copilotkit.ai
 # export INTELLIGENCE_GATEWAY_WS_URL=wss://realtime.intelligence.copilotkit.ai
+# export INTELLIGENCE_LEARNING_CONTAINER_ID=support-quality # Existing container in the API key's project.
 # export MERMAID_URL=https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
 
 # -- Agent Overrides (Optional) --

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -62,6 +62,7 @@ export default defineRailway(() => {
       INTELLIGENCE_API_URL: "https://api.intelligence.copilotkit.ai",
       INTELLIGENCE_GATEWAY_WS_URL:
         "wss://realtime.intelligence.copilotkit.ai",
+      INTELLIGENCE_LEARNING_CONTAINER_ID: preserve(),
       INTELLIGENCE_CHANNEL_NAME: "open-tag",
       PLAYWRIGHT_BROWSERS_PATH: "0",
       RAILPACK_DEPLOY_APT_PACKAGES:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ OPENAI_API_KEY=sk-...
 AGENT_URL=http://localhost:8123/
 INTELLIGENCE_API_KEY=cpk-...
 INTELLIGENCE_CHANNEL_NAME=open-tag
+# Optional: assign OpenTag Threads to an existing Learning Container.
+INTELLIGENCE_LEARNING_CONTAINER_ID=support-quality
 # Optional: use another user-facing identity, such as Kite.
 AGENT_DISPLAY_NAME=OpenTag
 ```
@@ -186,6 +188,11 @@ sources](#optional-research-sources).
 `INTELLIGENCE_API_URL` and `INTELLIGENCE_GATEWAY_WS_URL` already default to the
 production Intelligence endpoints in
 [`app/env.ts`](./app/env.ts), so leaving them unset is correct.
+
+`INTELLIGENCE_LEARNING_CONTAINER_ID` is also optional. When set, it must name
+an existing Learning Container in the project selected by
+`INTELLIGENCE_API_KEY`; when omitted, OpenTag does not assign Threads to a
+Learning Container.
 
 ### 4. Run the stack
 

--- a/app/env.test.ts
+++ b/app/env.test.ts
@@ -52,6 +52,27 @@ describe("readEnvironment", () => {
     });
   });
 
+  it("reads an optional Intelligence Learning Container ID", () => {
+    expect(
+      readEnvironment({
+        ...requiredEnvironment,
+        INTELLIGENCE_LEARNING_CONTAINER_ID: "  support-quality  ",
+      }),
+    ).toMatchObject({ learningContainerId: "support-quality" });
+  });
+
+  it.each([undefined, "", "   "])(
+    "leaves Learning disabled for container value %j",
+    (value) => {
+      expect(
+        readEnvironment({
+          ...requiredEnvironment,
+          INTELLIGENCE_LEARNING_CONTAINER_ID: value,
+        }),
+      ).toMatchObject({ learningContainerId: undefined });
+    },
+  );
+
   it("honors the agent display-name override", () => {
     expect(
       readEnvironment({

--- a/app/env.ts
+++ b/app/env.ts
@@ -12,6 +12,7 @@ export interface AppEnvironment {
   intelligenceApiKey: string;
   intelligenceApiUrl: string;
   intelligenceGatewayWsUrl: string;
+  learningContainerId?: string;
   channelName: string;
   port: number;
 }
@@ -52,6 +53,8 @@ export function readEnvironment(
     intelligenceGatewayWsUrl:
       env.INTELLIGENCE_GATEWAY_WS_URL ??
       DEFAULT_INTELLIGENCE_GATEWAY_WS_URL,
+    learningContainerId:
+      env.INTELLIGENCE_LEARNING_CONTAINER_ID?.trim() || undefined,
     channelName:
       env.INTELLIGENCE_CHANNEL_NAME ?? DEFAULT_INTELLIGENCE_CHANNEL_NAME,
     port: parsePort(env.PORT),

--- a/app/railway.test.ts
+++ b/app/railway.test.ts
@@ -109,6 +109,7 @@ describe("Railway deployment graph", () => {
           type: "literal",
           value: "wss://realtime.intelligence.copilotkit.ai",
         },
+        INTELLIGENCE_LEARNING_CONTAINER_ID: { type: "preserve" },
         INTELLIGENCE_CHANNEL_NAME: {
           type: "literal",
           value: "open-tag",

--- a/app/runtime-host.test.ts
+++ b/app/runtime-host.test.ts
@@ -40,6 +40,7 @@ describe("createOpenTagRuntime", () => {
 
     expect(runtime.mode).toBe("intelligence");
     expect(runtime.channels).toEqual(channels);
+    expect(runtime.learning).toBeUndefined();
     expect(intelligence.ɵgetApiUrl()).toBe(environment.intelligenceApiUrl);
     expect(intelligence.ɵgetClientWsUrl()).toContain("gateway.example.test");
     expect(
@@ -67,5 +68,17 @@ describe("createOpenTagRuntime", () => {
     await listener.channels?.stop();
     expect(stopSlack).toHaveBeenCalledOnce();
     expect(stopTeams).toHaveBeenCalledOnce();
+  });
+
+  it("passes the configured Learning Container to Intelligence Runtime", () => {
+    const { runtime } = createOpenTagRuntime({
+      environment: {
+        ...environment,
+        learningContainerId: "support-quality",
+      },
+      channels: [],
+    });
+
+    expect(runtime.learning).toEqual({ containerId: "support-quality" });
   });
 });

--- a/app/runtime-host.ts
+++ b/app/runtime-host.ts
@@ -32,6 +32,13 @@ export function createOpenTagRuntime(options: {
     intelligence,
     identifyUser: () => OPENTAG_SERVICE_USER,
     channels: options.channels,
+    ...(options.environment.learningContainerId
+      ? {
+          ɵlearning: {
+            containerId: options.environment.learningContainerId,
+          },
+        }
+      : {}),
   });
 
   const listener = createCopilotNodeListener({

--- a/setup.md
+++ b/setup.md
@@ -116,6 +116,7 @@ The AG-UI endpoint is `http://localhost:8123/`; `/health` reports the
 | `AGENT_URL` | Yes | Python AG-UI endpoint, locally `http://localhost:8123/` |
 | `INTELLIGENCE_API_KEY` | Yes | Runtime authentication; also selects the project |
 | `INTELLIGENCE_CHANNEL_NAME` | No | Defaults to `open-tag`; must match the Channel name exactly |
+| `INTELLIGENCE_LEARNING_CONTAINER_ID` | No | Assigns OpenTag Threads to this existing Learning Container |
 | `INTELLIGENCE_API_URL` | No | Defaults to `https://api.intelligence.copilotkit.ai` |
 | `INTELLIGENCE_GATEWAY_WS_URL` | No | Defaults to `wss://realtime.intelligence.copilotkit.ai` |
 | `AGENT_AUTH_HEADER` | No | Authorization header forwarded to the agent |
@@ -124,6 +125,9 @@ The AG-UI endpoint is `http://localhost:8123/`; `/health` reports the
 | `MERMAID_URL` | No | Overrides the Mermaid browser bundle URL used by diagram rendering |
 
 The API key selects a project; the Channel name selects a Channel inside it.
+When `INTELLIGENCE_LEARNING_CONTAINER_ID` is set, it must name an existing
+Learning Container in that same project. Omitting it preserves the default
+behavior and leaves OpenTag Threads unassigned to Learning.
 Legacy organization, project, Channel ID, and runtime-instance ID variables are
 not used. Slack and Teams credentials do not belong here — Intelligence owns
 them.


### PR DESCRIPTION
## Summary

- add optional `INTELLIGENCE_LEARNING_CONTAINER_ID` configuration through OpenTag's typed environment contract
- pass the configured ID to CopilotKit Runtime through the experimental `ɵlearning` option
- preserve the setting in Railway and document local/deployed usage without assigning a shared default

Existing deployments are unchanged when the variable is absent or blank.

## Validation

- `pnpm check-types`
- `pnpm test` — 224 passed
- `(cd agent && uv run pytest)` — 73 passed
- `node node_modules/railway/dist/iac/bin.js`
- `git diff --check origin/main...HEAD`
